### PR TITLE
Fix some CMake issues

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -72,6 +72,8 @@ ExternalProject_Add(fmt-ext
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/fmt
+        -DCMAKE_INSTALL_LIBDIR=lib
+    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/fmt/lib/libfmt.a
 )
 
 add_library(fmt INTERFACE)


### PR DESCRIPTION
- On some systems, CMake can default LIBDIR to lib64
- Ninja chokes on the missing target if the build byproduct is not set up