### PR TITLE
Add cleanup of expired invitations and extra invitations.

### DIFF
--- a/contracts/eden/include/constants.hpp
+++ b/contracts/eden/include/constants.hpp
@@ -12,4 +12,6 @@ namespace eden
    inline constexpr uint16_t max_active_members = 10000;
    inline constexpr uint32_t induction_expiration_secs = 7 * 24 * 60 * 60;  // 1 week
    inline constexpr double initial_market_fee = 0.05;
+
+   inline constexpr uint32_t max_gc_on_induction = 32;
 }  // namespace eden

--- a/contracts/eden/include/eden.hpp
+++ b/contracts/eden/include/eden.hpp
@@ -56,6 +56,8 @@ namespace eden
 
       void inducted(eosio::name inductee);
 
+      void gc(uint32_t limit);
+
       void notify_lognewtempl(int32_t template_id,
                               eosio::name authorized_creator,
                               eosio::name collection_name,
@@ -88,6 +90,7 @@ namespace eden
                  inductdonate,
                  inducted,
                  inductcancel,
+                 gc,
                  notify(token_contract, transfer),
                  notify(atomic_assets_account, lognewtempl),
                  notify(atomic_assets_account, logmint))

--- a/contracts/eden/include/inductions.hpp
+++ b/contracts/eden/include/inductions.hpp
@@ -121,6 +121,16 @@ namespace eden
    EOSIO_REFLECT(endorsed_induction, invitee, induction_id);
    using endorsed_induction_table_type = eosio::multi_index<"endind"_n, endorsed_induction>;
 
+   // Tracks invitees who had a large number of pending invitations that
+   // need to be cleaned up.
+   struct induction_gc
+   {
+      eosio::name invitee;
+      uint64_t primary_key() const { return invitee.value; }
+   };
+   EOSIO_REFLECT(induction_gc, invitee);
+   using induction_gc_table_type = eosio::multi_index<"inductgc"_n, induction_gc>;
+
    class inductions
    {
      private:
@@ -130,6 +140,7 @@ namespace eden
       globals globals;
 
       void check_new_induction(eosio::name invitee, eosio::name inviter) const;
+      bool is_valid_induction(const induction& induction) const;
       void check_valid_induction(const induction& induction) const;
       void validate_profile(const new_member_profile& new_member_profile) const;
       void validate_video(const std::string& video) const;
@@ -169,6 +180,10 @@ namespace eden
       void create_nfts(const induction& induction, int32_t template_id);
       void start_auction(const induction& induction, uint64_t asset_id);
       void erase_induction(const induction& induction);
+      uint32_t erase_expired(uint32_t limit);
+      uint32_t erase_by_inductee(eosio::name inductee, uint32_t limit);
+      uint32_t gc(uint32_t limit);
+      void queue_gc(eosio::name inductee);
       void create_induction(uint64_t id,
                             eosio::name inviter,
                             eosio::name invitee,

--- a/contracts/eden/src/actions/induct.cpp
+++ b/contracts/eden/src/actions/induct.cpp
@@ -99,6 +99,13 @@ namespace eden
       members.set_active(inductee, induction.new_member_profile().name);
       inductions.erase_induction(induction);
 
+      // Attempt to clean up pending inductions for this member,
+      // but give up if there are too many records to process.
+      if (!inductions.erase_by_inductee(inductee, max_gc_on_induction))
+      {
+         inductions.queue_gc(inductee);
+      }
+
       // If this is the last genesis member, activate the contract
       globals globals{get_self()};
       if (globals.get().stage == contract_stage::genesis)
@@ -108,6 +115,12 @@ namespace eden
             globals.set_stage(contract_stage::active);
          }
       }
+   }
+
+   void eden::gc(uint32_t limit)
+   {
+      inductions inductions{get_self()};
+      eosio::check(inductions.gc(limit) != limit, "Nothing to do.");
    }
 
    void eden::inductcancel(eosio::name account, uint64_t id)

--- a/contracts/eden/src/inductions.cpp
+++ b/contracts/eden/src/inductions.cpp
@@ -278,7 +278,10 @@ namespace eden
       auto end = invitee_idx.end();
       while (iter != end && limit > 0 && iter->invitee() == invitee)
       {
-         iter = invitee_idx.erase(iter);
+         auto next = iter;
+         ++next;
+         erase_induction(*iter);
+         iter = next;
          --limit;
       }
       return limit;
@@ -315,7 +318,10 @@ namespace eden
       auto end = created_idx.end();
       while (iter != end && limit > 0 && !is_valid_induction(*iter))
       {
-         iter = created_idx.erase(iter);
+         auto next = iter;
+         ++next;
+         erase_induction(*iter);
+         iter = next;
          --limit;
       }
       return limit;


### PR DESCRIPTION
- Automatically clear up to 32 invitations for the inducted member when an induction is completed
- The remaining invitations and all expired invitations can be cleared by the gc action.