### PR TITLE
Introduce react-query with the current member name

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -17,6 +17,7 @@
         "react": "~17",
         "react-dom": "~17",
         "react-icons": "^4.2.0",
+        "react-query": "^3.15.2",
         "ual-anchor": "^1.0.5",
         "ual-reactjs-renderer": "^0.3.1"
     },

--- a/packages/webapp/src/_app/hooks/index.ts
+++ b/packages/webapp/src/_app/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./forms";
 export * from "./fetch";
+export * from "./queries";

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "react-query";
+import { useUALAccount } from "../eos";
+import { getEdenMember } from "members";
+
+export const useMemberByAccountName = (accountName: string) =>
+    useQuery(
+        ["member", accountName],
+        async () => await getEdenMember(accountName),
+        {
+            staleTime: Infinity,
+            enabled: !!accountName,
+        }
+    );
+
+export const useCurrentMember = () => {
+    const [ualAccount] = useUALAccount();
+    return useMemberByAccountName(ualAccount?.accountName);
+};

--- a/packages/webapp/src/_app/ui/header-nav.tsx
+++ b/packages/webapp/src/_app/ui/header-nav.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useQuery, useQueryClient } from "react-query";
+import { useQueryClient } from "react-query";
 import { FaSignOutAlt } from "react-icons/fa";
 
-import { getEdenMember } from "members";
 import { useUALAccount } from "../eos";
+import { useCurrentMember } from "_app/hooks";
 import { ActionButton } from "./action-button";
 
 interface MenuItem {
@@ -77,15 +77,11 @@ const HeaderItemLink = ({
 };
 
 const AccountMenu = () => {
-    const queryClient = useQueryClient();
     const [ualAccount, ualLogout, ualShowModal] = useUALAccount();
-    const accountName = ualAccount ? ualAccount.accountName : undefined;
+    const accountName = ualAccount?.accountName;
 
-    const { data: member } = useQuery(
-        ["current-member", accountName],
-        async () => await getEdenMember(accountName),
-        { staleTime: Infinity, enabled: !!ualAccount }
-    );
+    const queryClient = useQueryClient();
+    const { data: member } = useCurrentMember();
 
     const onSignOut = () => {
         queryClient.clear();

--- a/packages/webapp/src/inductions/components/induction-lists/endorser-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/endorser-inductions.tsx
@@ -8,10 +8,10 @@ import {
     ActionButtonSize,
     ActionButtonType,
     useFetchedData,
+    useMemberByAccountName,
 } from "_app";
 import * as InductionTable from "_app/ui/table";
 import { Endorsement, Induction, InductionStatus } from "../../interfaces";
-import { EdenMember, getEdenMember } from "members";
 
 dayjs.extend(relativeTime.default);
 
@@ -64,10 +64,7 @@ const getTableData = (endorsements: Endorsement[]): InductionTable.Row[] => {
             end.induction_id
         );
 
-        const [inviter] = useFetchedData<EdenMember>(
-            getEdenMember,
-            end.inviter
-        );
+        const { data: inviter } = useMemberByAccountName(end.inviter);
 
         const remainingTime = induction
             ? dayjs().to(dayjs(induction.created_at).add(7, "day"), true)

--- a/packages/webapp/src/inductions/components/induction-lists/invitee-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/invitee-inductions.tsx
@@ -6,9 +6,9 @@ import {
     ActionButtonSize,
     ActionButtonType,
     useFetchedData,
+    useMemberByAccountName,
 } from "_app";
 import * as InductionTable from "_app/ui/table";
-import { EdenMember, getEdenMember } from "members";
 
 import { getEndorsementsByInductionId } from "../../api";
 import { getInductionStatus } from "../../utils";
@@ -57,10 +57,7 @@ const getTableData = (inductions: Induction[]): InductionTable.Row[] => {
             ind.id
         );
 
-        const [inviter] = useFetchedData<EdenMember>(
-            getEdenMember,
-            ind.inviter
-        );
+        const { data: inviter } = useMemberByAccountName(ind.inviter);
 
         const endorsers =
             allEndorsements

--- a/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
+import { useQueryClient } from "react-query";
 
 import {
     assetToString,
@@ -28,6 +29,7 @@ interface Props {
 
 export const InductionStepEndorsement = (props: Props) => {
     const router = useRouter();
+    const queryClient = useQueryClient();
     const [ualAccount] = useUALAccount();
     const [isLoading, setLoading] = useState(false);
     const [endorsements, setEndorsements] = useState([...props.endorsements]);
@@ -77,9 +79,13 @@ export const InductionStepEndorsement = (props: Props) => {
             });
             console.info("donation trx", signedTrx);
 
-            // router goes to the newly created member page after some tolerance
-            // time to make sure blockchain processed the transactions
+            // tolerance time to make sure blockchain processed the transactions
             await new Promise((resolve) => setTimeout(resolve, 4000));
+
+            // invalidate ["member", accountName] query so it will refetch with their full name
+            queryClient.invalidateQueries(["member", authorizerAccount]);
+
+            // router goes to the newly created member page
             router.push(`/members/${induction.invitee}`);
             return;
         } catch (error) {

--- a/packages/webapp/src/pages/_app.tsx
+++ b/packages/webapp/src/pages/_app.tsx
@@ -1,13 +1,20 @@
 import dynamic from "next/dynamic";
 import { AppProps } from "next/app";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 
 import "tailwindcss/tailwind.css";
 
+const queryClient = new QueryClient();
+
 const WebApp = ({ Component, pageProps }: AppProps) => {
     return (
-        <EdenUALProviderWithNoSSR>
-            <Component {...pageProps} />
-        </EdenUALProviderWithNoSSR>
+        <QueryClientProvider client={queryClient}>
+            <EdenUALProviderWithNoSSR>
+                <Component {...pageProps} />
+            </EdenUALProviderWithNoSSR>
+            <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
     );
 };
 

--- a/packages/webapp/src/pages/induction/index.tsx
+++ b/packages/webapp/src/pages/induction/index.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "react-query";
 import {
     SingleColLayout,
     CallToAction,
@@ -8,13 +7,14 @@ import {
     getIsCommunityActive,
     ActionButton,
     ActionButtonSize,
+    useCurrentMember,
 } from "_app";
 import {
     Endorsement,
     PendingInductions,
     getCurrentInductions,
 } from "inductions";
-import { getEdenMember, MemberStatus } from "members";
+import { MemberStatus } from "members";
 
 export const InductionPage = () => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
@@ -24,11 +24,10 @@ export const InductionPage = () => {
         isLoadingCommunityState,
     ] = useFetchedData<boolean>(getIsCommunityActive);
 
-    const { data: edenMember, isLoading: isLoadingEdenMember } = useQuery(
-        ["current-member", ualAccount?.accountName],
-        async () => await getEdenMember(ualAccount?.accountName),
-        { staleTime: Infinity, enabled: !!ualAccount }
-    );
+    const {
+        data: edenMember,
+        isLoading: isLoadingEdenMember,
+    } = useCurrentMember();
 
     const isActiveMember = edenMember?.status === MemberStatus.ActiveMember;
 

--- a/packages/webapp/src/pages/induction/index.tsx
+++ b/packages/webapp/src/pages/induction/index.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "react-query";
 import {
     SingleColLayout,
     CallToAction,
@@ -13,7 +14,7 @@ import {
     PendingInductions,
     getCurrentInductions,
 } from "inductions";
-import { getEdenMember, MemberStatus, EdenMember } from "members";
+import { getEdenMember, MemberStatus } from "members";
 
 export const InductionPage = () => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
@@ -22,15 +23,14 @@ export const InductionPage = () => {
         isActiveCommunity,
         isLoadingCommunityState,
     ] = useFetchedData<boolean>(getIsCommunityActive);
-    console.log("isActiveCommunity: ", isActiveCommunity);
 
-    const [edenMember, isLoadingEdenMember] = useFetchedData<EdenMember>(
-        getEdenMember,
-        ualAccount?.accountName
+    const { data: edenMember, isLoading: isLoadingEdenMember } = useQuery(
+        ["current-member", ualAccount?.accountName],
+        async () => await getEdenMember(ualAccount?.accountName),
+        { staleTime: Infinity, enabled: !!ualAccount }
     );
 
-    const isActiveMember =
-        edenMember && edenMember.status === MemberStatus.ActiveMember;
+    const isActiveMember = edenMember?.status === MemberStatus.ActiveMember;
 
     const [currentInductions, isLoadingInductions] = useFetchedData<any>(
         getCurrentInductions,

--- a/packages/webapp/src/pages/induction/init.tsx
+++ b/packages/webapp/src/pages/induction/init.tsx
@@ -2,18 +2,15 @@ import {
     CallToAction,
     Card,
     SingleColLayout,
-    useFetchedData,
+    useCurrentMember,
     useUALAccount,
 } from "_app";
-import { EdenMember, getEdenMember, MemberStatus } from "members";
+import { MemberStatus } from "members";
 import { InitInduction } from "inductions";
 
 export const InitInductionPage = () => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
-    const [edenMember, isLoading] = useFetchedData<EdenMember>(
-        getEdenMember,
-        ualAccount?.accountName
-    );
+    const { data: member, isLoading } = useCurrentMember();
 
     const renderContents = () => {
         if (!ualAccount) {
@@ -28,7 +25,7 @@ export const InitInductionPage = () => {
             return <Card title="Loading...">...</Card>;
         }
 
-        if (!edenMember || edenMember.status !== MemberStatus.ActiveMember) {
+        if (member?.status !== MemberStatus.ActiveMember) {
             return (
                 <CallToAction buttonLabel="Get started" href="#">
                     Ready to join Eden? The membership process begins with an

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -1632,6 +1639,11 @@ before-after-hook@^2.2.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.0.tgz#09c40d92e936c64777aa385c4e9b904f8147eaf0"
   integrity sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -1666,6 +1678,19 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.5.3.tgz#c75c39d923ae8af6284a893bfdc8bd3996d2dd2d"
+  integrity sha512-OLOXfwReZa2AAAh9yOUyiALB3YxBe0QpThwwuyRHLgpl8bSznSDmV6Mz7LeBJg1VZsMcDcNMy7B53w12qHrIhQ==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.0.4"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -2493,6 +2518,11 @@ detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+
+detect-node@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.5.tgz#9d270aa7eaa5af0b72c4c9d9b814e7f4ce738b79"
+  integrity sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw==
 
 detective@^5.2.0:
   version "5.2.0"
@@ -3895,6 +3925,11 @@ jest-worker@27.0.0-next.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4243,6 +4278,14 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.2.0.tgz#0e8bc823e2aaca8a0942567d12ed14f389eec153"
   integrity sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ==
 
+match-sorter@^6.0.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
+  integrity sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -4314,6 +4357,11 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -4514,6 +4562,13 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.16, nanoid@^3.1.22:
   version "3.1.22"
@@ -5605,6 +5660,15 @@ react-is@16.13.1, react-is@^16.6.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-query@^3.15.2:
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.15.2.tgz#4ff4ffe9ff5e3bf002a7e863cc01b9d58c5fae01"
+  integrity sha512-7pm/WR+zl064W0pfQffayM0Jmgsz2VcoDL0pRFk06ERpMSYLQjX0fFZfvVRIgJVRjgS3A04pSY1iOYdw92dzdA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
@@ -5834,6 +5898,11 @@ regexpp@^3.0.0, regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 repeating@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
@@ -5920,17 +5989,17 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -6882,6 +6951,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## What is this?

This introduces the `react-query` package to the project and uses member names as an example. This particular PR showcases how much more efficient `react-query` can make our web app in terms of network request load.

Before, every link you clicked on would trigger another API call to lookup the name of the currently-logged-in user (and any other member names on the page on at a time) by their EOS account name. That's a lot of API calls for data we already have. Now (and without the introduction of a bunch of redux boilerplate) it looks it up once--when the user logs in or when a different user info is fetched for the first time. And when they sign out, the cache is cleared.

Also, when a non-member donates, the cache for their name is invalidated, which triggers a refetch to get their new full name from the member table and display it anywhere in the UI that's observing. (For example, after donation, their user name in the nav bar should automatically display.)

## Other uses for React Query

`react-query` will serve us well in other ways too--pagination comes to mind...or infinite scroll. And it really does replace the need much of the time for solutions like redux when dealing with fetched information. 

## Reading
* https://react-query.tanstack.com
* You should keep this handy at first too: https://react-query.tanstack.com/guides/important-defaults

## Follow-up work for another PR
* Anywhere we are displaying EOS account names but could instead display a member name, use this query!
* Other queries
* Pagination