### PR TITLE
member page / card spacing improvements

### DIFF
--- a/packages/webapp/src/members/components/member-card.tsx
+++ b/packages/webapp/src/members/components/member-card.tsx
@@ -15,7 +15,7 @@ export const MemberCard = ({ member }: Props) => {
     return (
         <div
             data-testid={`member-card-${member.account}`}
-            className="px-2 sm:px-8 flex flex-col max-w-xl"
+            className="px-2 flex flex-col max-w-2xl"
         >
             <MemberSocialLinks member={member} />
             <section className="py-4">
@@ -38,7 +38,7 @@ export const MemberCard = ({ member }: Props) => {
 
 const MemberBio = ({ bio }: { bio: string }) => {
     const [expanded, setExpanded] = useState(false);
-    const TRUNCATION_THRESHOLD_IN_CHARS = 235;
+    const TRUNCATION_THRESHOLD_IN_CHARS = 310;
     const shouldTruncate = bio.length > TRUNCATION_THRESHOLD_IN_CHARS;
 
     const toggleExpanded = (e: React.MouseEvent) => {

--- a/packages/webapp/src/pages/members/[id].tsx
+++ b/packages/webapp/src/pages/members/[id].tsx
@@ -37,8 +37,8 @@ export const MemberPage = ({ account }: Props) => {
         return (
             <RawLayout title={`${member.name}'s Profile`}>
                 <Card>
-                    <div className="flex justify-center items-center space-y-10 xl:space-y-0 xl:space-x-10 flex-col xl:flex-row">
-                        <div className="max-w-xl">
+                    <div className="flex justify-center items-center space-y-10 xl:space-y-0 xl:space-x-20 flex-col xl:flex-row">
+                        <div className="max-w-2xl">
                             <MemberHoloCard member={member} />
                         </div>
                         <MemberCard member={member} />


### PR DESCRIPTION
Before
<img width="1302" alt="Screen Shot 2021-05-10 at 9 20 09 PM" src="https://user-images.githubusercontent.com/5896030/117743811-86a45880-b1d5-11eb-9dee-6474852152ec.png">

After 
<img width="1270" alt="Screen Shot 2021-05-10 at 9 20 57 PM" src="https://user-images.githubusercontent.com/5896030/117743879-a6d41780-b1d5-11eb-954d-7eda5f3adbeb.png">

