### PR TITLE
Launch Readiness: Tailor Induction UI to Genesis Mode

### DIFF
--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -1,6 +1,7 @@
 import { useQueries, useQuery, UseQueryResult } from "react-query";
 
 import { EdenMember, getEdenMember } from "members";
+import { getIsCommunityActive } from "_app/api";
 
 import { useUALAccount } from "../eos";
 
@@ -28,3 +29,6 @@ export const useCurrentMember = () => {
     const [ualAccount] = useUALAccount();
     return useMemberByAccountName(ualAccount?.accountName);
 };
+
+export const useIsCommunityActive = () =>
+    useQuery("isCommunityActive", getIsCommunityActive);

--- a/packages/webapp/src/_app/utils/index.ts
+++ b/packages/webapp/src/_app/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./asset";
 export * from "./error-handler";
+export * from "./ipfs";

--- a/packages/webapp/src/_app/utils/ipfs.ts
+++ b/packages/webapp/src/_app/utils/ipfs.ts
@@ -1,0 +1,10 @@
+import CID from "cids";
+
+export const validateCID = (str: string) => {
+    try {
+        new CID(str);
+        return true;
+    } catch {
+        return false;
+    }
+};

--- a/packages/webapp/src/inductions/components/get-an-invite-cta.tsx
+++ b/packages/webapp/src/inductions/components/get-an-invite-cta.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { ActionButton, ActionButtonSize } from "_app";
-import { InductionJourneyContainer, InductionRole } from "./induction-journey-container";
+import {
+    InductionJourneyContainer,
+    InductionRole,
+} from "./induction-journey-container";
 
 export const GetAnInviteCTA = () => {
     return (
@@ -11,7 +14,10 @@ export const GetAnInviteCTA = () => {
                     invitation. Reach out to a current member to get yours!
                     We'll guide you through the rest.
                 </p>
-                <ActionButton href="#" size={ActionButtonSize.L}>
+                <ActionButton
+                    href="https://www.notion.so/edenos/Getting-an-Invite-2d38947d5be94dcb84dfa1ae48894802"
+                    size={ActionButtonSize.L}
+                >
                     Learn more
                 </ActionButton>
             </>

--- a/packages/webapp/src/inductions/components/induction-journey-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journey-container.tsx
@@ -50,7 +50,7 @@ export const INVITER_INDUCTION_STEPS: Step[] = [
     },
     {
         title: "ALL DONE",
-        text: "NFTs are minted. We have new member!",
+        text: "NFTs are minted. We have a new member!",
     },
 ];
 

--- a/packages/webapp/src/inductions/components/induction-journey-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journey-container.tsx
@@ -85,10 +85,16 @@ export enum InductionRole {
 interface Props {
     role: InductionRole;
     step: 1 | 2 | 3 | 4 | 5;
+    vAlign?: "top" | "center";
     children: React.ReactNode;
 }
 
-export const InductionJourneyContainer = ({ role, step, children }: Props) => {
+export const InductionJourneyContainer = ({
+    role,
+    step,
+    vAlign = "center",
+    children,
+}: Props) => {
     let steps: Step[];
 
     switch (role) {
@@ -103,9 +109,11 @@ export const InductionJourneyContainer = ({ role, step, children }: Props) => {
             break;
     }
 
+    const vAlignClass = vAlign === "center" ? "lg:items-center" : "";
+
     return (
         <Card>
-            <div className="flex lg:items-center flex-col lg:flex-row">
+            <div className={`flex flex-col lg:flex-row ${vAlignClass}`}>
                 <div className="lg:w-1/2 xl:w-3/5 px-4 sm:px-12 md:px-16 xl:px-24 pt-8 pb-4">
                     {children}
                 </div>

--- a/packages/webapp/src/inductions/components/induction-journey-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journey-container.tsx
@@ -54,9 +54,32 @@ export const INVITER_INDUCTION_STEPS: Step[] = [
     },
 ];
 
+export const GENESIS_INDUCTION_STEPS: Step[] = [
+    {
+        title: "SET UP YOUR PROFILE",
+        text: "Let the community know who you are.",
+    },
+    {
+        title: "DONATE",
+        text: `Give ${assetToString(
+            minimumDonationAmount
+        )} to the Eden community.`,
+    },
+    {
+        title: "STAND BY",
+        text:
+            "All Genesis members must complete the process for the community to go live.",
+    },
+    {
+        title: "YOU'RE IN",
+        text: "NFTs are minted. Welcome to Eden.",
+    },
+];
+
 export enum InductionRole {
     INVITEE = "invitee",
     INVITER = "inviter",
+    GENESIS = "genesis",
 }
 
 interface Props {
@@ -69,6 +92,9 @@ export const InductionJourneyContainer = ({ role, step, children }: Props) => {
     let steps: Step[];
 
     switch (role) {
+        case InductionRole.GENESIS:
+            steps = GENESIS_INDUCTION_STEPS;
+            break;
         case InductionRole.INVITEE:
             steps = INVITEE_INDUCTION_STEPS;
             break;

--- a/packages/webapp/src/inductions/components/induction-journey-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journey-container.tsx
@@ -72,7 +72,7 @@ export const GENESIS_INDUCTION_STEPS: Step[] = [
     },
     {
         title: "YOU'RE IN",
-        text: "NFTs are minted. Welcome to Eden.",
+        text: "The community is activated. Welcome to Eden.",
     },
 ];
 

--- a/packages/webapp/src/inductions/components/induction-lists/endorser-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/endorser-inductions.tsx
@@ -152,7 +152,7 @@ const EndorserInductionStatus = ({
                     fullWidth
                     href={`/induction/${induction.id}`}
                 >
-                    Endorse
+                    Review &amp; Endorse
                 </ActionButton>
             );
         default:

--- a/packages/webapp/src/inductions/components/induction-lists/invitee-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/invitee-inductions.tsx
@@ -32,8 +32,8 @@ const INVITEE_INDUCTION_COLUMNS: InductionTable.Column[] = [
         label: "Inviter",
     },
     {
-        key: "voters",
-        label: "Voters",
+        key: "witnesses",
+        label: "Witnesses",
         className: "hidden md:flex",
     },
     {
@@ -82,7 +82,7 @@ const getTableData = (inductions: Induction[]): InductionTable.Row[] => {
         return {
             key: ind.id,
             inviter: inviter ? inviter.name : ind.inviter,
-            voters: endorsers,
+            witnesses: endorsers,
             time_remaining: remainingTime,
             status: (
                 <InviteeInductionStatus

--- a/packages/webapp/src/inductions/components/induction-lists/inviter-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/inviter-inductions.tsx
@@ -31,8 +31,8 @@ const INVITER_INDUCTION_COLUMNS: InductionTable.Column[] = [
         label: "Invitee",
     },
     {
-        key: "inviter_voters",
-        label: "Inviter & Voters",
+        key: "inviter_witnesses",
+        label: "Inviter & Witnesses",
         className: "hidden md:flex",
     },
     {
@@ -74,7 +74,7 @@ const getTableData = (inductions: Induction[]): InductionTable.Row[] => {
         return {
             key: ind.id,
             invitee: ind.new_member_profile.name || ind.invitee,
-            inviter_voters: endorsers,
+            inviter_witnesses: endorsers,
             time_remaining: remainingTime,
             status: (
                 <InviterInductionStatus
@@ -153,7 +153,7 @@ const InviterInductionStatus = ({
                     fullWidth
                     href={`/induction/${induction.id}`}
                 >
-                    Endorse
+                    Review &amp; Endorse
                 </ActionButton>
             );
         default:

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -134,7 +134,7 @@ export const InductionProfileForm = ({
             </Form.LabeledSet>
 
             <Form.LabeledSet
-                label="Profile image attribution (optional)"
+                label="Credit for profile image goes to (optional)"
                 htmlFor="attributions"
                 className="col-span-6"
             >
@@ -248,7 +248,7 @@ export const InductionProfileForm = ({
             <div className="col-span-6 p-3 border rounded-md">
                 <Form.Checkbox
                     id="reviewed"
-                    label="I understand that the profile information I have provided above will be published permanently to an immutable, public blockchain and will no longer be under the control of EdenOS and/or this community. By submitting this form, I give my consent to that effect."
+                    label="I understand and acknowledge that I am publishing the profile information above permanently and irrevocably to an immutable, public blockchain. When I submit this form, it cannot be undone."
                     value={Number(consentsToPublish)}
                     onChange={() => setConsentsToPublish(!consentsToPublish)}
                 />

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent, useState } from "react";
 
 import { EdenNftSocialHandles } from "nfts";
-import { useFormFields, Form, Heading, ActionButton } from "_app";
+import { useFormFields, Form, Heading, ActionButton, Link } from "_app";
 import { NewMemberProfile } from "../interfaces";
 import CID from "cids";
 
@@ -69,11 +69,24 @@ export const InductionProfileForm = ({
                 />
             </Form.LabeledSet>
 
-            <Form.LabeledSet
-                label="Profile image (IPFS CID)"
-                htmlFor="img"
-                className="col-span-6"
-            >
+            <Form.LabeledSet label="" htmlFor="img" className="col-span-6">
+                <div className="flex items-center mb-1 space-x-1">
+                    <p className="text-sm font-medium text-gray-700">
+                        Profile image (IPFS CID)
+                    </p>
+                    <Link
+                        isExternal
+                        href="https://www.notion.so/edenos/Upload-Profile-Photo-c15a7a050d3c411faca21a3cd3d2f0a3"
+                        target="_blank"
+                        className="hover:no-underline"
+                    >
+                        <div className="flex justify-center items-center h-5 w-5 rounded-full bg-gray-300 hover:bg-gray-200 border border-gray-400">
+                            <span className="text-gray-800 hover:text-gray-700 font-semibold text-sm">
+                                ?
+                            </span>
+                        </div>
+                    </Link>
+                </div>
                 <Form.Input
                     id="img"
                     type="text"
@@ -98,7 +111,7 @@ export const InductionProfileForm = ({
                         This is not a valid IPFS CID.
                     </p>
                 )}
-                {fields.img && isValidCID ? (
+                {isValidCID ? (
                     <img
                         src={`https://ipfs.io/ipfs/${fields.img}`}
                         alt="profile pic"

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -1,9 +1,15 @@
-import React, { FormEvent, useState } from "react";
+import React, { FormEvent, useEffect, useState } from "react";
 
 import { EdenNftSocialHandles } from "nfts";
-import { useFormFields, Form, Heading, ActionButton, Link } from "_app";
+import {
+    useFormFields,
+    Form,
+    Heading,
+    ActionButton,
+    Link,
+    validateCID,
+} from "_app";
 import { NewMemberProfile } from "../interfaces";
-import CID from "cids";
 
 interface Props {
     newMemberProfile: NewMemberProfile;
@@ -26,10 +32,16 @@ export const InductionProfileForm = ({
     const [consentsToPublish, setConsentsToPublish] = useState(false);
 
     const [fields, setFields] = useFormFields({ ...newMemberProfile });
+
     const [socialFields, setSocialFields] = useFormFields(
         convertNewMemberProfileSocial(newMemberProfile.social)
     );
+
     const [isValidCID, setIsValidCID] = useState(false);
+
+    useEffect(() => {
+        setIsValidCID(validateCID(fields.img));
+    }, []);
 
     const onChangeFields = (e: React.ChangeEvent<HTMLInputElement>) =>
         setFields(e);
@@ -94,16 +106,11 @@ export const InductionProfileForm = ({
                     disabled={isLoading || disabled}
                     value={fields.img}
                     onChange={(e) => {
-                        try {
-                            const cid = new CID(e.currentTarget.value);
-                            setIsValidCID(true);
-                        } catch {
-                            setIsValidCID(false);
-                        } finally {
-                            onChangeFields(
-                                e as React.ChangeEvent<HTMLInputElement>
-                            );
-                        }
+                        const isValid = validateCID(e.currentTarget.value);
+                        setIsValidCID(isValid);
+                        onChangeFields(
+                            e as React.ChangeEvent<HTMLInputElement>
+                        );
                     }}
                 />
                 {fields.img && !isValidCID && (

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -69,7 +69,7 @@ export const InductionProfileForm = ({
             </Form.LabeledSet>
 
             <Form.LabeledSet
-                label="Profile image (IPFS hash)"
+                label="Profile image (IPFS CID)"
                 htmlFor="img"
                 className="col-span-6"
             >

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -146,7 +146,7 @@ export const InductionProfileForm = ({
                 Social handles and links
             </Heading>
             <Form.LabeledSet
-                label="EOSCommunity username"
+                label="EOSCommunity.org username"
                 htmlFor="eosCommunity"
                 className="col-span-6 md:col-span-3 lg:col-span-6 xl:col-span-3"
             >

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useState } from "react";
+import React, { FormEvent, useMemo, useState } from "react";
 
 import { EdenNftSocialHandles } from "nfts";
 import {
@@ -37,11 +37,9 @@ export const InductionProfileForm = ({
         convertNewMemberProfileSocial(newMemberProfile.social)
     );
 
-    const [isValidCID, setIsValidCID] = useState(false);
-
-    useEffect(() => {
-        setIsValidCID(validateCID(fields.img));
-    }, []);
+    const isPhotoValidCID = useMemo(() => validateCID(fields.img), [
+        fields.img,
+    ]);
 
     const onChangeFields = (e: React.ChangeEvent<HTMLInputElement>) =>
         setFields(e);
@@ -105,20 +103,14 @@ export const InductionProfileForm = ({
                     required
                     disabled={isLoading || disabled}
                     value={fields.img}
-                    onChange={(e) => {
-                        const isValid = validateCID(e.currentTarget.value);
-                        setIsValidCID(isValid);
-                        onChangeFields(
-                            e as React.ChangeEvent<HTMLInputElement>
-                        );
-                    }}
+                    onChange={onChangeFields}
                 />
-                {fields.img && !isValidCID && (
+                {fields.img && !isPhotoValidCID && (
                     <p className={"text-red-500 text-sm mt-1"}>
                         This is not a valid IPFS CID.
                     </p>
                 )}
-                {isValidCID ? (
+                {isPhotoValidCID ? (
                     <img
                         src={`https://ipfs.io/ipfs/${fields.img}`}
                         alt="profile pic"

--- a/packages/webapp/src/inductions/components/induction-profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-profile-form.tsx
@@ -23,6 +23,7 @@ export const InductionProfileForm = ({
     onSubmit,
 }: Props) => {
     const [isLoading, setIsLoading] = useState(false);
+    const [consentsToPublish, setConsentsToPublish] = useState(false);
 
     const [fields, setFields] = useFormFields({ ...newMemberProfile });
     const [socialFields, setSocialFields] = useFormFields(
@@ -224,9 +225,21 @@ export const InductionProfileForm = ({
                 />
             </Form.LabeledSet>
 
+            <div className="col-span-6 p-3 border rounded-md">
+                <Form.Checkbox
+                    id="reviewed"
+                    label="I understand that the profile information I have provided above will be published permanently to an immutable, public blockchain and will no longer be under the control of EdenOS and/or this community. By submitting this form, I give my consent to that effect."
+                    value={Number(consentsToPublish)}
+                    onChange={() => setConsentsToPublish(!consentsToPublish)}
+                />
+            </div>
+
             {onSubmit && (
                 <div className="pt-4">
-                    <ActionButton isSubmit disabled={isLoading}>
+                    <ActionButton
+                        isSubmit
+                        disabled={isLoading || !consentsToPublish}
+                    >
                         {isLoading ? "Submitting..." : "Submit"}
                     </ActionButton>
                 </div>

--- a/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
@@ -332,6 +332,7 @@ const DonationForm = ({
     setReviewStep,
     submitDonation,
 }: DonationFormProps) => {
+    const [isProfileReviewed, setReviewedProfile] = useState(false);
     return isInvitee ? (
         <div className="space-y-3">
             <Text>
@@ -343,13 +344,23 @@ const DonationForm = ({
                     " Keep in mind that modifying your profile will require your endorsers to submit their endorsements again."}
             </Text>
             <Text>
-                If everything looks good, click on the button below to make your
-                donation to the Eden community.
+                If everything looks good, submit your donation to proceed.
                 {isCommunityActive &&
                     " Once completed, your membership will be activated and your Eden NFTs will be minted and distributed."}
             </Text>
+            <div className="p-3 border rounded-md">
+                <Form.Checkbox
+                    id="reviewed"
+                    label="I have carefully reviewed my profile image, links and information below and confirm their accuracy. I understand that by submitting my donation, my Eden NFTs will be minted and changes to my profile or this NFT series will not be possible."
+                    value={Number(isProfileReviewed)}
+                    onChange={() => setReviewedProfile(!isProfileReviewed)}
+                />
+            </div>
             <div className="pt-1">
-                <ActionButton disabled={isLoading} onClick={submitDonation}>
+                <ActionButton
+                    disabled={isLoading || !isProfileReviewed}
+                    onClick={submitDonation}
+                >
                     {isLoading
                         ? "Submitting donation..."
                         : `Donate ${assetToString(minimumDonationAmount)}`}

--- a/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
@@ -33,6 +33,7 @@ import {
 interface Props {
     induction: Induction;
     endorsements: Endorsement[];
+    isCommunityActive?: boolean;
     setReviewStep: (step: "profile" | "video") => void;
 }
 
@@ -151,15 +152,29 @@ export const InductionStepEndorsement = (props: Props) => {
             </span>
         );
 
+    const getInductionJourneyRole = () => {
+        if (!props.isCommunityActive) {
+            return InductionRole.GENESIS;
+        } else if (!ualAccount || isInvitee) {
+            return InductionRole.INVITEE;
+        }
+        return InductionRole.INVITER;
+    };
+
+    const getInductionJourneyStep = () => {
+        if (!props.isCommunityActive) {
+            return 2;
+        } else if (isFullyEndorsed) {
+            return 4;
+        }
+        return 3;
+    };
+
     return (
         <>
             <InductionJourneyContainer
-                role={
-                    !ualAccount || isInvitee
-                        ? InductionRole.INVITEE
-                        : InductionRole.INVITER
-                }
-                step={isFullyEndorsed ? 4 : 3}
+                role={getInductionJourneyRole()}
+                step={getInductionJourneyStep()}
             >
                 <Heading size={1} className="mb-2">
                     {isFullyEndorsed ? "Pending donation" : "Endorsements"}
@@ -187,6 +202,7 @@ export const InductionStepEndorsement = (props: Props) => {
                     {isFullyEndorsed ? (
                         <DonationForm
                             isLoading={isLoading}
+                            isCommunityActive={props.isCommunityActive}
                             setReviewStep={props.setReviewStep}
                             submitDonation={submitDonation}
                             isInvitee={isInvitee}
@@ -297,12 +313,14 @@ const EndorsingForm = ({
 };
 
 interface DonationFormProps {
+    isCommunityActive?: boolean;
     isInvitee: boolean;
     isLoading: boolean;
     setReviewStep: (step: "profile" | "video") => void;
     submitDonation: () => void;
 }
 const DonationForm = ({
+    isCommunityActive,
     isInvitee,
     isLoading,
     setReviewStep,
@@ -311,17 +329,18 @@ const DonationForm = ({
     return isInvitee ? (
         <div className="space-y-3">
             <Text>
-                This is your last chance to review your profile for completeness
-                and accuracy. If anything needs to be corrected,{" "}
+                This is your last chance to review your profile below for
+                completeness and accuracy. If anything needs to be corrected,{" "}
                 <Link onClick={() => setReviewStep("profile")}>click here</Link>
-                . Keep in mind that modifying your profile will require your
-                endorsers to submit their endorsements again.
+                .
+                {isCommunityActive &&
+                    " Keep in mind that modifying your profile will require your endorsers to submit their endorsements again."}
             </Text>
             <Text>
                 If everything looks good, click on the button below to make your
-                donation to the Eden community. Once completed, your membership
-                will be activated and your Eden NFTs will be minted and
-                distributed.
+                donation to the Eden community.
+                {isCommunityActive &&
+                    " Once completed, your membership will be activated and your Eden NFTs will be minted and distributed."}
             </Text>
             <div className="pt-1">
                 <ActionButton disabled={isLoading} onClick={submitDonation}>

--- a/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-endorsement.tsx
@@ -184,21 +184,27 @@ export const InductionStepEndorsement = (props: Props) => {
                     {getInductionRemainingTimeDays(induction)}.
                 </Text>
                 <div>
-                    <Heading size={3} className="mb-2">
-                        Endorsement status:
-                    </Heading>
-                    <ul className="mb-4 ml-2">
-                        {endorsements.map((endorser) => (
-                            <li key={endorser.id}>
-                                {getEndorserStatus(endorser)}{" "}
-                                <Link href={`/members/${endorser.endorser}`}>
-                                    <span className="text-gray-800 hover:underline">
-                                        {getEndorserName(endorser)}
-                                    </span>
-                                </Link>
-                            </li>
-                        ))}
-                    </ul>
+                    {endorsements.length > 0 && (
+                        <>
+                            <Heading size={3} className="mb-2">
+                                Endorsement status:
+                            </Heading>
+                            <ul className="mb-4 ml-2">
+                                {endorsements.map((endorser) => (
+                                    <li key={endorser.id}>
+                                        {getEndorserStatus(endorser)}{" "}
+                                        <Link
+                                            href={`/members/${endorser.endorser}`}
+                                        >
+                                            <span className="text-gray-800 hover:underline">
+                                                {getEndorserName(endorser)}
+                                            </span>
+                                        </Link>
+                                    </li>
+                                ))}
+                            </ul>
+                        </>
+                    )}
                     {isFullyEndorsed ? (
                         <DonationForm
                             isLoading={isLoading}
@@ -350,12 +356,19 @@ const DonationForm = ({
                 </ActionButton>
             </div>
         </div>
-    ) : (
+    ) : isCommunityActive ? (
         <Text>
             This induction is fully endorsed! As soon as the prospective member
             completes their donation to the Eden community, their membership
             will be activated and their Eden NFTs will be minted and
             distributed.
+        </Text>
+    ) : (
+        <Text>
+            As soon as this prospective member completes their donation to the
+            Eden community, their membership is ready for activation. Once all
+            Genesis members are fully inducted, memberships will be activated
+            and Eden NFTs will be distributed.
         </Text>
     );
 };

--- a/packages/webapp/src/inductions/components/induction-step-profile.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-profile.tsx
@@ -17,10 +17,15 @@ import { getInductionRemainingTimeDays } from "inductions/utils";
 
 interface Props {
     induction: Induction;
+    isCommunityActive?: boolean;
     isReviewing?: boolean;
 }
 
-export const InductionStepProfile = ({ induction, isReviewing }: Props) => {
+export const InductionStepProfile = ({
+    induction,
+    isCommunityActive,
+    isReviewing,
+}: Props) => {
     const [ualAccount] = useUALAccount();
 
     const [submittedProfile, setSubmittedProfile] = useState(false);
@@ -47,7 +52,10 @@ export const InductionStepProfile = ({ induction, isReviewing }: Props) => {
     };
 
     // Invitee profile submission confirmation
-    if (submittedProfile) return <ProfileSubmitConfirmation />;
+    if (submittedProfile)
+        return (
+            <ProfileSubmitConfirmation isCommunityActive={isCommunityActive} />
+        );
 
     // Invitee profile create/update form
     if (ualAccount?.accountName === induction.invitee) {
@@ -55,6 +63,7 @@ export const InductionStepProfile = ({ induction, isReviewing }: Props) => {
             <CreateModifyProfile
                 induction={induction}
                 onSubmit={submitInductionProfileTransaction}
+                isCommunityActive={isCommunityActive}
                 isReviewing={isReviewing}
             />
         );
@@ -64,42 +73,60 @@ export const InductionStepProfile = ({ induction, isReviewing }: Props) => {
     return <WaitingForInviteeProfile induction={induction} />;
 };
 
-const ProfileSubmitConfirmation = () => (
-    <InductionJourneyContainer role={InductionRole.INVITEE} step={3}>
-        <Heading size={1} className="mb-5">
-            Success!
-        </Heading>
-        <div className="space-y-3 mb-8">
-            <Text className="leading-normal">
-                Thanks for submitting your profile.
-            </Text>
-            <Text className="leading-normal">
-                Your inviter and witnesses will be in touch to schedule the
-                short video induction ceremony. Now's a good time to reach out
-                to them to let them know you're ready.
-            </Text>
-        </div>
-        <ActionButton
-            onClick={() => window.location.reload()}
-            size={ActionButtonSize.L}
+const ProfileSubmitConfirmation = ({
+    isCommunityActive,
+}: {
+    isCommunityActive?: boolean;
+}) => {
+    return (
+        <InductionJourneyContainer
+            role={
+                isCommunityActive
+                    ? InductionRole.INVITEE
+                    : InductionRole.GENESIS
+            }
+            step={isCommunityActive ? 3 : 2}
         >
-            See induction status
-        </ActionButton>
-    </InductionJourneyContainer>
-);
+            <Heading size={1} className="mb-5">
+                Success!
+            </Heading>
+            <div className="space-y-3 mb-8">
+                <Text className="leading-normal">
+                    Thanks for submitting your profile.
+                </Text>
+                <Text className="leading-normal">
+                    {isCommunityActive
+                        ? "Your inviter and witnesses will be in touch to schedule the short video induction ceremony. Now's a good time to reach out to them to let them know you're ready."
+                        : "The next step in the induction process is to submit your donation. Once all Genesis members have completed their profiles and donations, the community will be activated."}
+                </Text>
+            </div>
+            <ActionButton
+                onClick={() => window.location.reload()}
+                size={ActionButtonSize.L}
+            >
+                {isCommunityActive ? "See induction status" : "Onward!"}
+            </ActionButton>
+        </InductionJourneyContainer>
+    );
+};
 
 interface CreateModifyProfileProps {
     induction: Induction;
     onSubmit?: (newMemberProfile: NewMemberProfile) => Promise<void>;
+    isCommunityActive?: boolean;
     isReviewing?: boolean;
 }
 
 const CreateModifyProfile = ({
     induction,
     onSubmit,
+    isCommunityActive,
     isReviewing,
 }: CreateModifyProfileProps) => (
-    <InductionJourneyContainer role={InductionRole.INVITEE} step={2}>
+    <InductionJourneyContainer
+        role={isCommunityActive ? InductionRole.INVITEE : InductionRole.GENESIS}
+        step={isCommunityActive ? 2 : 1}
+    >
         <Heading size={1} className="mb-2">
             {isReviewing
                 ? "Review your Eden profile"

--- a/packages/webapp/src/inductions/components/induction-step-profile.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-profile.tsx
@@ -70,7 +70,13 @@ export const InductionStepProfile = ({
     }
 
     // Inviter/endorsers profile pending screen
-    return <WaitingForInviteeProfile induction={induction} />;
+    return (
+        <WaitingForInviteeProfile
+            induction={induction}
+            isCommunityActive={isCommunityActive}
+            isInviter={ualAccount?.accountName === induction.inviter}
+        />
+    );
 };
 
 const ProfileSubmitConfirmation = ({
@@ -143,32 +149,56 @@ const CreateModifyProfile = ({
     </InductionJourneyContainer>
 );
 
-const WaitingForInviteeProfile = ({ induction }: { induction: Induction }) => (
-    <InductionJourneyContainer role={InductionRole.INVITER} step={2}>
-        <Heading size={1} className="mb-5">
-            Waiting for invitee
-        </Heading>
-        <div className="space-y-3 mb-8">
-            <Text className="leading-normal">
-                We're waiting on{" "}
-                <span className="font-semibold">{induction.invitee}</span> to
-                set up their Eden profile.
-            </Text>
-            <Text className="leading-normal">
-                Encourage the invitee to sign into the Membership dashboard with
-                their blockchain account to complete their profile. Or you can
-                share this direct link with them:
-            </Text>
-            <Text className="leading-normal break-all">
-                <Link href={window.location.href}>{window.location.href}</Link>
-            </Text>
-            <Text className="leading-normal font-medium">
-                This invitation expires in{" "}
-                {getInductionRemainingTimeDays(induction)}.
-            </Text>
-        </div>
-        <ActionButton href="/induction" size={ActionButtonSize.L}>
-            Membership dashboard
-        </ActionButton>
-    </InductionJourneyContainer>
-);
+const WaitingForInviteeProfile = ({
+    induction,
+    isCommunityActive,
+    isInviter,
+}: {
+    induction: Induction;
+    isCommunityActive?: boolean;
+    isInviter: boolean;
+}) => {
+    const getInductionJourneyRole = () => {
+        if (!isCommunityActive) {
+            return InductionRole.GENESIS;
+        } else if (isInviter) {
+            return InductionRole.INVITER;
+        }
+        return InductionRole.INVITEE; // not logged in, active community
+    };
+
+    return (
+        <InductionJourneyContainer
+            role={getInductionJourneyRole()}
+            step={!isCommunityActive ? 1 : 2}
+        >
+            <Heading size={1} className="mb-5">
+                Waiting for invitee
+            </Heading>
+            <div className="space-y-3 mb-8">
+                <Text className="leading-normal">
+                    We're waiting on{" "}
+                    <span className="font-semibold">{induction.invitee}</span>{" "}
+                    to set up their Eden profile.
+                </Text>
+                <Text className="leading-normal">
+                    Encourage the invitee to sign into the Membership dashboard
+                    with their blockchain account to complete their profile. Or
+                    you can share this direct link with them:
+                </Text>
+                <Text className="leading-normal break-all">
+                    <Link href={window.location.href}>
+                        {window.location.href}
+                    </Link>
+                </Text>
+                <Text className="leading-normal font-medium">
+                    This invitation expires in{" "}
+                    {getInductionRemainingTimeDays(induction)}.
+                </Text>
+            </div>
+            <ActionButton href="/induction" size={ActionButtonSize.L}>
+                Membership dashboard
+            </ActionButton>
+        </InductionJourneyContainer>
+    );
+};

--- a/packages/webapp/src/inductions/components/induction-step-profile.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-profile.tsx
@@ -132,6 +132,7 @@ const CreateModifyProfile = ({
     <InductionJourneyContainer
         role={isCommunityActive ? InductionRole.INVITEE : InductionRole.GENESIS}
         step={isCommunityActive ? 2 : 1}
+        vAlign="top"
     >
         <Heading size={1} className="mb-2">
             {isReviewing

--- a/packages/webapp/src/members/components/members-grid.tsx
+++ b/packages/webapp/src/members/components/members-grid.tsx
@@ -60,7 +60,7 @@ export const MemberSquare = ({ member }: { member: MemberData }) => {
 const baseBadge = "rounded px-2 text-xs";
 
 const MemberImage = ({ member }: { member: MemberData }) => {
-    const imageClass = "h-40 sm:h-32 w-full object-cover object-top mx-auto";
+    const imageClass = "h-60 md:h-44 w-full object-cover object-center mx-auto";
     if (member.account) {
         return (
             <div className="relative">

--- a/packages/webapp/src/pages/induction/[id].tsx
+++ b/packages/webapp/src/pages/induction/[id].tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
 
-import { CallToAction, RawLayout, SingleColLayout, useFetchedData } from "_app";
+import {
+    CallToAction,
+    RawLayout,
+    SingleColLayout,
+    useFetchedData,
+    useIsCommunityActive,
+} from "_app";
 import {
     getInductionWithEndorsements,
     Induction,
@@ -20,7 +26,12 @@ export const InductionDetailsPage = () => {
         "profile" | "video" | undefined
     >();
 
-    const [inductionEndorsements, isLoading] = useFetchedData<{
+    const {
+        data: isCommunityActive,
+        isLoading: isLoadingCommunityState,
+    } = useIsCommunityActive();
+
+    const [inductionEndorsements, isLoadingEndorsements] = useFetchedData<{
         induction: Induction;
         endorsements: Endorsement[];
     }>(getInductionWithEndorsements, inductionId);
@@ -39,7 +50,13 @@ export const InductionDetailsPage = () => {
         if (!induction) return "";
 
         if (reviewStep === "profile") {
-            return <InductionStepProfile induction={induction} isReviewing />;
+            return (
+                <InductionStepProfile
+                    induction={induction}
+                    isCommunityActive={isCommunityActive}
+                    isReviewing
+                />
+            );
         }
 
         if (reviewStep === "video") {
@@ -54,7 +71,12 @@ export const InductionDetailsPage = () => {
 
         switch (status) {
             case InductionStatus.waitingForProfile:
-                return <InductionStepProfile induction={induction} />;
+                return (
+                    <InductionStepProfile
+                        induction={induction}
+                        isCommunityActive={isCommunityActive}
+                    />
+                );
             case InductionStatus.waitingForVideo:
                 return (
                     <InductionStepVideo
@@ -67,6 +89,7 @@ export const InductionDetailsPage = () => {
                     <InductionStepEndorsement
                         induction={induction}
                         endorsements={endorsements}
+                        isCommunityActive={isCommunityActive}
                         setReviewStep={setReviewStep}
                     />
                 );
@@ -75,7 +98,7 @@ export const InductionDetailsPage = () => {
         }
     };
 
-    return isLoading ? (
+    return isLoadingEndorsements || isLoadingCommunityState ? (
         <p>Loading Induction...</p>
     ) : status === InductionStatus.invalid ? (
         <RawLayout title="Invite not found">

--- a/packages/webapp/src/pages/induction/[id].tsx
+++ b/packages/webapp/src/pages/induction/[id].tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useRouter } from "next/router";
 
-import { RawLayout, SingleColLayout, useFetchedData } from "_app";
+import { CallToAction, RawLayout, SingleColLayout, useFetchedData } from "_app";
 import {
     getInductionWithEndorsements,
     Induction,
@@ -78,13 +78,11 @@ export const InductionDetailsPage = () => {
     return isLoading ? (
         <p>Loading Induction...</p>
     ) : status === InductionStatus.invalid ? (
-        <RawLayout title="Induction not found">
-            <div className="text-center max-w p-8">
-                <p>
-                    Perhaps this induction was completed successfully or, in the
-                    worst case scenario, it was expired after 7 days.
-                </p>
-            </div>
+        <RawLayout title="Invite not found">
+            <CallToAction href="/induction" buttonLabel="Membership Dashboard">
+                Hmmm... this invitation couldn't be found. The invitee may have
+                already been inducted, or their invitation could have expired.
+            </CallToAction>
         </RawLayout>
     ) : (
         <SingleColLayout title={`Induction #${inductionId}`}>

--- a/packages/webapp/src/pages/induction/index.tsx
+++ b/packages/webapp/src/pages/induction/index.tsx
@@ -4,10 +4,10 @@ import {
     Card,
     useFetchedData,
     useUALAccount,
-    getIsCommunityActive,
     ActionButton,
     ActionButtonSize,
     useCurrentMember,
+    useIsCommunityActive,
 } from "_app";
 import {
     Endorsement,
@@ -20,10 +20,10 @@ import { MemberStatus } from "members";
 export const InductionPage = () => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
 
-    const [
-        isActiveCommunity,
-        isLoadingCommunityState,
-    ] = useFetchedData<boolean>(getIsCommunityActive);
+    const {
+        data: isActiveCommunity,
+        isLoading: isLoadingCommunityState,
+    } = useIsCommunityActive();
 
     const {
         data: edenMember,


### PR DESCRIPTION
We focused on providing a sensible experience and flow for inviters, invitees and witnesses. But after our small genesis induction user test, it was evident we didn't pay as much attention to invitees in Genesis mode. They were seeing UI as if the community were active

This addresses that. (Although we're in dire need of a good refactor of these flows; they've evolved organically and are difficult to reason about at the moment...but that will come later, together with some good cypress tests.)

This also addresses some of the other user feedback we received and witnessed during our test genesis induction yesterday.