### PR TITLE
Induction Journey Fixes

### DIFF
--- a/packages/webapp/src/inductions/components/get-an-invite-cta.tsx
+++ b/packages/webapp/src/inductions/components/get-an-invite-cta.tsx
@@ -7,7 +7,7 @@ import {
 
 export const GetAnInviteCTA = () => {
     return (
-        <InductionJourneyContainer role={InductionRole.INVITER} step={1}>
+        <InductionJourneyContainer role={InductionRole.INVITEE} step={1}>
             <>
                 <p className="mb-10 text-2xl font-medium title-font text-gray-900">
                     Ready to join Eden? The membership process begins with an

--- a/packages/webapp/src/inductions/components/induction-lists/inviter-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/inviter-inductions.tsx
@@ -21,7 +21,7 @@ export const InviterInductions = ({ inductions }: Props) => (
     <InductionTable.Table
         columns={INVITER_INDUCTION_COLUMNS}
         data={getTableData(inductions)}
-        tableHeader="My outstanding invitations"
+        tableHeader="People I'm inviting"
     />
 );
 

--- a/packages/webapp/src/inductions/components/induction-step-profile.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-profile.tsx
@@ -18,17 +18,22 @@ import { getInductionRemainingTimeDays } from "inductions/utils";
 interface Props {
     induction: Induction;
     isCommunityActive?: boolean;
+    isEndorser: boolean;
     isReviewing?: boolean;
 }
 
 export const InductionStepProfile = ({
     induction,
     isCommunityActive,
+    isEndorser,
     isReviewing,
 }: Props) => {
     const [ualAccount] = useUALAccount();
 
     const [submittedProfile, setSubmittedProfile] = useState(false);
+
+    const isInvitee = ualAccount?.accountName === induction.invitee;
+    const isInviter = ualAccount?.accountName === induction.inviter;
 
     const submitInductionProfileTransaction = async (
         newMemberProfile: NewMemberProfile
@@ -58,7 +63,7 @@ export const InductionStepProfile = ({
         );
 
     // Invitee profile create/update form
-    if (ualAccount?.accountName === induction.invitee) {
+    if (isInvitee) {
         return (
             <CreateModifyProfile
                 induction={induction}
@@ -69,12 +74,12 @@ export const InductionStepProfile = ({
         );
     }
 
-    // Inviter/endorsers profile pending screen
+    // Not logged in OR inviter/endorsers profile pending screen
     return (
         <WaitingForInviteeProfile
             induction={induction}
             isCommunityActive={isCommunityActive}
-            isInviter={ualAccount?.accountName === induction.inviter}
+            isInviterOrEndorser={isInviter || isEndorser}
         />
     );
 };
@@ -153,19 +158,19 @@ const CreateModifyProfile = ({
 const WaitingForInviteeProfile = ({
     induction,
     isCommunityActive,
-    isInviter,
+    isInviterOrEndorser,
 }: {
     induction: Induction;
     isCommunityActive?: boolean;
-    isInviter: boolean;
+    isInviterOrEndorser: boolean;
 }) => {
     const getInductionJourneyRole = () => {
         if (!isCommunityActive) {
             return InductionRole.GENESIS;
-        } else if (isInviter) {
+        } else if (isInviterOrEndorser) {
             return InductionRole.INVITER;
         }
-        return InductionRole.INVITEE; // not logged in, active community
+        return InductionRole.INVITEE;
     };
 
     return (

--- a/packages/webapp/src/inductions/components/induction-step-video.tsx
+++ b/packages/webapp/src/inductions/components/induction-step-video.tsx
@@ -12,7 +12,7 @@ import {
     convertPendingProfileToMemberData,
     getInductionRemainingTimeDays,
 } from "../utils";
-import { Endorsement, Induction } from "../interfaces";
+import { Induction } from "../interfaces";
 import { setInductionVideoTransaction } from "../transactions";
 import { InductionVideoForm } from "./induction-video-form";
 import {
@@ -23,13 +23,13 @@ import {
 
 interface Props {
     induction: Induction;
-    endorsements: Endorsement[];
+    isEndorser: boolean;
     isReviewing?: boolean;
 }
 
 export const InductionStepVideo = ({
     induction,
-    endorsements,
+    isEndorser,
     isReviewing,
 }: Props) => {
     const [ualAccount] = useUALAccount();
@@ -56,11 +56,6 @@ export const InductionStepVideo = ({
 
     const memberData = convertPendingProfileToMemberData(induction);
 
-    const isEndorser = () =>
-        endorsements.find(
-            (endorsement) => endorsement.endorser === ualAccount?.accountName
-        );
-
     // Invitee/Endorser: Induction ceremony completion confirmation
     if (submittedVideo) {
         return (
@@ -72,7 +67,7 @@ export const InductionStepVideo = ({
     }
 
     // Invitee/Endorser: Waiting for induction ceremony
-    if (isEndorser()) {
+    if (isEndorser) {
         return (
             <>
                 <AddUpdateVideoHash


### PR DESCRIPTION
* "Ready to Join Eden" showed the induction journey graphic from the perspective of the Inviter instead of the Invitee. Fixed.
* Witnesses saw the induction journey graphic from the perspective of the Invitee instead of the Inviter on the "Waiting for Invitee" page. Fixed.
* Clarify invitation table header language.
* Added a TODO inline as a note for upcoming refactor. 