### PR TITLE
Clean up addtogenesis  

### DIFF
--- a/contracts/eden/CMakeLists.txt
+++ b/contracts/eden/CMakeLists.txt
@@ -24,9 +24,9 @@ add_custom_command(TARGET eden-abigen POST_BUILD
     COMMAND ${ROOT_BINARY_DIR}/cltester eden-abigen.wasm >${ROOT_BINARY_DIR}/eden.abi
 )
 
-add_executable(test-eden tests/test-eden.cpp src/globals.cpp src/accounts.cpp src/members.cpp)
+add_executable(test-eden tests/test-eden.cpp src/globals.cpp src/accounts.cpp src/members.cpp src/atomicassets.cpp)
 target_include_directories(test-eden PUBLIC include)
-target_include_directories(test-eden PUBLIC ../token/include ../boot/include)
+target_include_directories(test-eden PUBLIC ../token/include ../boot/include ../../external/atomicassets-contract/include)
 target_link_libraries(test-eden catch2 cltestlib)
 set_target_properties(test-eden PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
 eden_tester_test(test-eden)

--- a/contracts/eden/include/eden-atomicassets.hpp
+++ b/contracts/eden/include/eden-atomicassets.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <eosio/asset.hpp>
 #include <eosio/check.hpp>
 #include <eosio/contract.hpp>
 #include <eosio/dispatcher.hpp>
@@ -60,6 +61,14 @@ namespace eden::atomicassets
                         eosio::name collection_name,
                         eosio::name schema_name,
                         const std::vector<format>& schema_format);
+      void mintasset(eosio::name authorized_creator,
+                     eosio::name collection_name,
+                     eosio::name schema_name,
+                     int32_t template_id,
+                     eosio::name new_asset_owner,
+                     const attribute_map& immutable_data,
+                     const attribute_map& mutable_data,
+                     const std::vector<eosio::asset>& tokens_to_back);
       void addnotifyacc(eosio::name collection_name, eosio::name account_to_add);
    };
    EOSIO_ACTIONS(atomicassets_contract,
@@ -69,6 +78,7 @@ namespace eden::atomicassets
                  setcoldata,
                  createschema,
                  extendschema,
+                 mintasset,
                  addnotifyacc);
 
    attribute_map read_immutable_data(eosio::name contract,
@@ -81,6 +91,11 @@ namespace eden::atomicassets
                         eosio::name schema,
                         double market_fee,
                         const attribute_map& attrs);
+
+   bool is_locked(eosio::name contract, eosio::name collection, int32_t template_id);
+
+   // Used for testing
+   std::vector<int32_t> assets_by_owner(eosio::name contract, eosio::name owner);
 
    void validate_ipfs(const std::string& cid);
 }  // namespace eden::atomicassets

--- a/contracts/eden/include/inductions.hpp
+++ b/contracts/eden/include/inductions.hpp
@@ -163,6 +163,7 @@ namespace eden
       {
       }
 
+      const induction_table_type& get_table() { return induction_tb; }
       const induction& get_induction(uint64_t id) const;
       const induction& get_endorsed_induction(eosio::name invitee) const;
       bool has_induction(eosio::name invitee) const;
@@ -184,6 +185,7 @@ namespace eden
       bool is_endorser(uint64_t id, eosio::name witness) const;
 
       void create_nfts(const induction& induction, int32_t template_id);
+      void mint_nft(int template_id, eosio::name new_asset_owner);
       void start_auction(const induction& induction, uint64_t asset_id);
       void erase_induction(const induction& induction);
       uint32_t erase_expired(uint32_t limit, std::vector<eosio::name>& removed_members);
@@ -201,6 +203,7 @@ namespace eden
                               eosio::name endorser,
                               uint64_t induction_id,
                               bool endorsed = false);
+      void add_endorsement(const induction& induction, eosio::name endorser, bool endorsed);
 
       // Should only be used during genesis
       void endorse_all(const induction& induction);

--- a/contracts/eden/include/members.hpp
+++ b/contracts/eden/include/members.hpp
@@ -70,6 +70,7 @@ namespace eden
       }
 
       const member& get_member(eosio::name account);
+      const member_table_type& get_table() const { return member_tb; }
       void create(eosio::name account);
       void remove_if_pending(eosio::name account);
       bool is_new_member(eosio::name account) const;

--- a/contracts/eden/src/actions/genesis.cpp
+++ b/contracts/eden/src/actions/genesis.cpp
@@ -23,31 +23,38 @@ namespace eden
 
       eosio::check(globals(get_self()).get().stage == contract_stage::genesis, "Not in genesis");
 
+      inductions inductions(get_self());
+
       std::vector<eosio::name> initial_members;
-      member_table_type member_tb(get_self(), default_scope);
-      for(const auto& member : member_tb)
+      for (const auto& member : members.get_table())
       {
          initial_members.push_back(member.account());
+         // If the NFTs for this member have already been issued by a sufficiently
+         // recent version of the eden contract which leaves the max_supply unlocked
+         // until genesis is complete, then retroactively issue an NFT to the
+         // new genesis member.
+         if (member.status() == active_member &&
+             !atomicassets::is_locked(atomic_assets_account, get_self(), member.nft_template_id()))
+         {
+            inductions.mint_nft(member.nft_template_id(), newmember);
+         }
       }
 
       members.create(newmember);
 
       // for each current induction, add newmember as a witness
-      inductions inductions(get_self());
-
-      induction_table_type inductions_tb(get_self(), default_scope);
-      eosio::check(inductions_tb.begin() != inductions_tb.end(), "No inductions");
-      auto genesis_video = inductions_tb.begin()->video();
-
-      for(const auto& induction: inductions_tb)
+      for (const auto& induction : inductions.get_table())
       {
-         inductions_tb.modify(induction, get_self(), [&](auto& row){ ++row.endorsements(); });
-         inductions.create_endorsement(induction.inviter(), induction.invitee(), newmember, induction.id(), true);
+         inductions.add_endorsement(induction, newmember, true);
       }
-      
+
       uint64_t induction_id = members.stats().active_members + members.stats().pending_members;
       auto inviter = get_self();
       auto invitee = newmember;
+
+      // Extract the genesis video from an existing induction
+      eosio::check(inductions.get_table().begin() != inductions.get_table().end(), "No inductions");
+      auto genesis_video = inductions.get_table().begin()->video();
 
       auto total_endorsements = initial_members.size();
       inductions.create_induction(induction_id, inviter, invitee, total_endorsements,
@@ -61,7 +68,7 @@ namespace eden
          }
       }
    }
-   
+
    void eden::genesis(std::string community,
                       eosio::symbol community_symbol,
                       eosio::asset minimum_donation,

--- a/contracts/eden/src/atomicassets.cpp
+++ b/contracts/eden/src/atomicassets.cpp
@@ -129,6 +129,25 @@ namespace eden::atomicassets
       }
    }
 
+   bool is_locked(eosio::name contract, eosio::name collection, int32_t template_id)
+   {
+      ::atomicassets::templates_t templates(contract, collection.value);
+      const auto& templ = templates.get(
+          template_id, ("fail to read template id " + std::to_string(template_id)).c_str());
+      return templ.max_supply != 0;
+   }
+
+   std::vector<int32_t> assets_by_owner(eosio::name contract, eosio::name owner)
+   {
+      ::atomicassets::assets_t assets(contract, owner.value);
+      std::vector<int32_t> result;
+      for (const auto& asset : assets)
+      {
+         result.push_back(asset.template_id);
+      }
+      return result;
+   }
+
    void validate_ipfs(const std::string& cid)
    {
       eosio::check(!cid.empty(), "CID is empty");

--- a/contracts/eden/src/inductions.cpp
+++ b/contracts/eden/src/inductions.cpp
@@ -63,6 +63,13 @@ namespace eden
       });
    }
 
+   void inductions::add_endorsement(const induction& induction, eosio::name endorser, bool endorsed)
+   {
+      induction_tb.modify(induction, contract, [&](auto& row) { ++row.endorsements(); });
+      create_endorsement(induction.inviter(), induction.invitee(), endorser, induction.id(),
+                         endorsed);
+   }
+
    void inductions::update_profile(const induction& induction,
                                    const new_member_profile& new_member_profile)
    {
@@ -202,15 +209,30 @@ namespace eden
          immutable_data.push_back({"attributions", induction.new_member_profile().attributions});
       }
       const auto collection_name = contract;
+      const auto max_supply = (globals.get().stage == contract_stage::genesis)
+                                  ? 0u
+                                  : uint32_t{induction.endorsements() + 2};
       eosio::action{{contract, "active"_n},
                     atomic_assets_account,
                     "createtempl"_n,
-                    std::tuple{contract, collection_name, schema_name, true, true,
-                               uint32_t{induction.endorsements() + 2}, immutable_data}}
+                    std::tuple{contract, collection_name, schema_name, true, true, max_supply,
+                               immutable_data}}
           .send();
 
       // Finalize and clean up induction state.  Must happen last.
       eosio::action{{contract, "active"_n}, contract, "inducted"_n, induction.invitee()}.send();
+   }
+
+   void inductions::mint_nft(int template_id, eosio::name new_asset_owner)
+   {
+      const auto collection_name = contract;
+      eosio::action{{contract, "active"_n},
+                    atomic_assets_account,
+                    "mintasset"_n,
+                    std::tuple{contract, collection_name, schema_name, template_id, new_asset_owner,
+                               atomicassets::attribute_map{}, atomicassets::attribute_map{},
+                               std::vector<eosio::asset>{}}}
+          .send();
    }
 
    void inductions::create_nfts(const induction& induction, int32_t template_id)
@@ -226,16 +248,9 @@ namespace eden
          itr++;
       }
 
-      const auto collection_name = contract;
       for (eosio::name new_asset_owner : new_owners)
       {
-         eosio::action{{contract, "active"_n},
-                       atomic_assets_account,
-                       "mintasset"_n,
-                       std::tuple{contract, collection_name, schema_name, template_id,
-                                  new_asset_owner, atomicassets::attribute_map{},
-                                  atomicassets::attribute_map{}, std::vector<eosio::asset>{}}}
-             .send();
+         mint_nft(template_id, new_asset_owner);
       }
    }
 

--- a/contracts/eden/src/members.cpp
+++ b/contracts/eden/src/members.cpp
@@ -85,6 +85,13 @@ namespace eden
          if (stats().pending_members == 0)
          {
             globals.set_stage(contract_stage::active);
+            // Lock the supply of genesis NFTs
+            for (const auto& member : member_tb)
+            {
+               eosio::action({contract, "active"_n}, atomic_assets_account, "locktemplate"_n,
+                             std::tuple(contract, contract, member.nft_template_id()))
+                   .send();
+            }
          }
       }
    }


### PR DESCRIPTION
Don't lock the supply of NFTs until genesis is complete, so that members who are patched in can receive all the NFTs.