### PR TITLE
Post-footer home cleanup. Improve action button and CTA.

### DIFF
--- a/packages/webapp/src/_app/ui/action-button.tsx
+++ b/packages/webapp/src/_app/ui/action-button.tsx
@@ -63,12 +63,7 @@ export const ActionButton = ({
     const cursorClass = disabled ? "cursor-not-allowed" : "cursor-pointer";
     const buttonClass = `${baseClass} ${size} ${widthClass} ${colorClass} ${cursorClass} ${className}`;
 
-    let targetProps = {
-        target,
-        rel: isExternal ? "noopener noreferrer" : undefined,
-    };
-
-    if (onClick) {
+    if (isSubmit || onClick) {
         return (
             <button
                 onClick={onClick}
@@ -86,7 +81,12 @@ export const ActionButton = ({
 
     if (isExternal) {
         return (
-            <a className={buttonClass} href={href} {...targetProps}>
+            <a
+                className={buttonClass}
+                href={href}
+                rel="noopener noreferrer"
+                target={target}
+            >
                 {isLoading && (
                     <FaSpinner className="inline-flex animate-spin mr-2" />
                 )}
@@ -97,7 +97,7 @@ export const ActionButton = ({
 
     return (
         <NextLink href={href}>
-            <a className={buttonClass} {...targetProps}>
+            <a className={buttonClass} target={target}>
                 {isLoading && (
                     <FaSpinner className="inline-flex animate-spin mr-2" />
                 )}

--- a/packages/webapp/src/_app/ui/action-button.tsx
+++ b/packages/webapp/src/_app/ui/action-button.tsx
@@ -4,7 +4,6 @@ import { FaSpinner } from "react-icons/fa";
 
 interface Props {
     children: React.ReactNode;
-    href?: string;
     onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     type?: ActionButtonType;
     isSubmit?: boolean;
@@ -13,6 +12,9 @@ interface Props {
     size?: ActionButtonSize;
     fullWidth?: boolean;
     className?: string;
+    href?: string;
+    target?: string;
+    isExternal?: boolean;
 }
 
 export enum ActionButtonSize {
@@ -42,7 +44,6 @@ export enum ActionButtonType {
  */
 export const ActionButton = ({
     children,
-    href,
     onClick,
     isSubmit,
     disabled,
@@ -51,6 +52,9 @@ export const ActionButton = ({
     fullWidth,
     isLoading,
     className = "",
+    href = "#",
+    target,
+    isExternal,
 }: Props) => {
     const baseClass =
         "inline-block items-center text-center border focus:outline-none";
@@ -59,30 +63,46 @@ export const ActionButton = ({
     const cursorClass = disabled ? "cursor-not-allowed" : "cursor-pointer";
     const buttonClass = `${baseClass} ${size} ${widthClass} ${colorClass} ${cursorClass} ${className}`;
 
-    if (href) {
+    let targetProps = {
+        target,
+        rel: isExternal ? "noopener noreferrer" : undefined,
+    };
+
+    if (onClick) {
         return (
-            <NextLink href={href}>
-                <a className={buttonClass}>
-                    {isLoading && (
-                        <FaSpinner className="inline-flex animate-spin mr-2" />
-                    )}
-                    {children}
-                </a>
-            </NextLink>
+            <button
+                onClick={onClick}
+                type={isSubmit ? "submit" : "button"}
+                className={buttonClass}
+                disabled={disabled}
+            >
+                {isLoading && (
+                    <FaSpinner className="inline-flex animate-spin mr-1 mb-1 align-middle" />
+                )}
+                {children}
+            </button>
+        );
+    }
+
+    if (isExternal) {
+        return (
+            <a className={buttonClass} href={href} {...targetProps}>
+                {isLoading && (
+                    <FaSpinner className="inline-flex animate-spin mr-2" />
+                )}
+                {children}
+            </a>
         );
     }
 
     return (
-        <button
-            onClick={onClick}
-            type={isSubmit ? "submit" : "button"}
-            className={buttonClass}
-            disabled={disabled}
-        >
-            {isLoading && (
-                <FaSpinner className="inline-flex animate-spin mr-1 mb-1 align-middle" />
-            )}
-            {children}
-        </button>
+        <NextLink href={href}>
+            <a className={buttonClass} {...targetProps}>
+                {isLoading && (
+                    <FaSpinner className="inline-flex animate-spin mr-2" />
+                )}
+                {children}
+            </a>
+        </NextLink>
     );
 };

--- a/packages/webapp/src/_app/ui/call-to-action.tsx
+++ b/packages/webapp/src/_app/ui/call-to-action.tsx
@@ -1,9 +1,11 @@
 import { ActionButton, ActionButtonSize, Card } from "_app";
 
 interface Props {
-    href?: string;
-    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     buttonLabel?: string;
+    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    href?: string;
+    target?: string;
+    isExternal?: boolean;
     children: React.ReactNode;
 }
 
@@ -12,6 +14,8 @@ export const CallToAction = ({
     onClick,
     buttonLabel,
     children,
+    target,
+    isExternal,
 }: Props) => (
     <Card>
         <section className="text-gray-600 body-font">
@@ -26,6 +30,8 @@ export const CallToAction = ({
                             onClick={onClick}
                             size={ActionButtonSize.L}
                             className="flex-shrink-0 mt-10 sm:mt-0"
+                            target={target}
+                            isExternal={isExternal}
                         >
                             {buttonLabel || "Go"}
                         </ActionButton>

--- a/packages/webapp/src/inductions/components/get-an-invite-cta.tsx
+++ b/packages/webapp/src/inductions/components/get-an-invite-cta.tsx
@@ -17,6 +17,8 @@ export const GetAnInviteCTA = () => {
                 <ActionButton
                     href="https://www.notion.so/edenos/Getting-an-Invite-2d38947d5be94dcb84dfa1ae48894802"
                     size={ActionButtonSize.L}
+                    target="_blank"
+                    isExternal
                 >
                     Learn more
                 </ActionButton>

--- a/packages/webapp/src/pages/index.tsx
+++ b/packages/webapp/src/pages/index.tsx
@@ -1,40 +1,55 @@
-import { Card, Link, SingleColLayout, Text } from "_app";
+import { CallToAction, Card, Heading, Link, RawLayout, Text } from "_app";
 
 export const Index = () => (
-    <SingleColLayout>
-        <Card title="Welcome to Eden" className="col-span-3 xl:col-span-2">
-            <div className="space-y-3 text-gray-800">
-                <Text>
-                    Eden is a community working to maximize the power and
-                    independence of its members, thereby securing life, liberty,
-                    property, and justice for all.
-                </Text>
-                <Text>
-                    A team of people can be more powerful than the sum of its
-                    members, but all teams need a means to reach consensus, or
-                    they will fall apart. Unfortunately, traditional democratic
-                    processes end up empowering politicians and disempowering
-                    the people who participate. EdenOS is a revolutionary new
-                    democratic process that protects and enhances the
-                    independence and power of those who join. When you join the
-                    Eden community, you gain access to a group of people working
-                    together to empower you and your family to make a bigger
-                    impact in the world.
-                </Text>
-                <Text>
-                    To learn more about Eden and how you can get involved, visit{" "}
-                    <Link
-                        href="http://eden.eoscommunity.org"
-                        target="_blank"
-                        isExternal
-                    >
-                        eden.eoscommunity.org
-                    </Link>
-                    .
-                </Text>
+    <RawLayout>
+        <CallToAction
+            href="http://eden.eoscommunity.org"
+            buttonLabel="Learn more"
+            target="_blank"
+            isExternal
+        >
+            Eden is a community working to maximize the power and independence
+            of its members, thereby securing life, liberty, property, and
+            justice for all.
+        </CallToAction>
+        <Card>
+            <div className="grid grid-cols-2 gap-4 md:gap-16 lg:gap-24 lg:px-24 xl:px-56 text-gray-800">
+                <div className="col-span-2 md:col-span-1 space-y-4">
+                    <Heading size={2}>Welcome to Eden</Heading>
+                    <Text>
+                        A team of people can be more powerful than the sum of
+                        its members, but all teams need a means to reach
+                        consensus, or they will fall apart. Unfortunately,
+                        traditional democratic processes end up empowering
+                        politicians and disempowering the people who
+                        participate.
+                    </Text>
+                </div>
+                <div className="col-span-2 md:col-span-1 space-y-4">
+                    <Text>
+                        EdenOS is a revolutionary new democratic process that
+                        protects and enhances the independence and power of
+                        those who join. When you join the Eden community, you
+                        gain access to a group of people working together to
+                        empower you and your family to make a bigger impact in
+                        the world.
+                    </Text>
+                    <Text>
+                        To learn more about Eden and how you can get involved,
+                        visit{" "}
+                        <Link
+                            href="http://eden.eoscommunity.org"
+                            target="_blank"
+                            isExternal
+                        >
+                            eden.eoscommunity.org
+                        </Link>
+                        .
+                    </Text>
+                </div>
             </div>
         </Card>
-    </SingleColLayout>
+    </RawLayout>
 );
 
 export default Index;


### PR DESCRIPTION
The Home page was looking a bit bare after moving links down into the footer. (heck, it was bare even before that!) This splits the information up a bit...makes it feel more full and easier on the eyes. I think?

Let me know what you think. (Compare eden-dev.vercel.app with this branch's deploy.)

I'm also improving the way `ActionButton` handles external links in this PR...similar to prior improvements to `Link`.