### PR TITLE
patch: upload to ipfs when trx has multi-actions

### DIFF
--- a/packages/webapp/src/_api/handlers/ipfs-upload-handler.ts
+++ b/packages/webapp/src/_api/handlers/ipfs-upload-handler.ts
@@ -52,17 +52,14 @@ const parseActionIpfsCid = async (
     serializedTransaction: Uint8Array
 ): Promise<ActionIpfsData> => {
     const trx = eosDefaultApi.deserializeTransaction(serializedTransaction);
-    const { actions } = trx;
-    if (!actions || actions.length !== 1) {
-        // TODO: we might support multiple actions files/uploads in the future
-        throw new BadRequestError(["only 1 action per upload"]);
-    }
 
-    const serializedAction = actions[0];
-    if (
-        !validUploadActions[serializedAction.account] ||
-        !validUploadActions[serializedAction.account][serializedAction.name]
-    ) {
+    const serializedAction = trx.actions.find(
+        (action: any) =>
+            validUploadActions[action.account] &&
+            validUploadActions[action.account][action.name]
+    );
+
+    if (!serializedAction) {
         throw new BadRequestError([
             "contract action is not whitelisted for upload",
         ]);


### PR DESCRIPTION
We are blocking a transaction with multiple actions when it's submitted to upload an IPFS through our API:
![image](https://user-images.githubusercontent.com/79721020/119139541-22716800-ba11-11eb-9d85-2b695dac74e7.png)


When the user is using FUEL or perhaps another "power up" action in conjunction we should support it. This PR addresses it.