### PR TITLE
fix blocktimestamp timezone issue

### DIFF
--- a/packages/webapp/src/_app/eos/utils.ts
+++ b/packages/webapp/src/_app/eos/utils.ts
@@ -73,3 +73,7 @@ export const serializeType = async (
 export const hash256EosjsSerialBuffer = (
     buffer: eosjsSerialize.SerialBuffer
 ): string => hash.sha256().update(buffer.asUint8Array()).digest("hex");
+
+export const eosBlockTimestampISO = (timestamp: string) => {
+    return timestamp.endsWith("Z") ? timestamp : timestamp + "Z";
+};

--- a/packages/webapp/src/inductions/utils.ts
+++ b/packages/webapp/src/inductions/utils.ts
@@ -1,5 +1,8 @@
 import dayjs from "dayjs";
+
+import { eosBlockTimestampISO } from "_app";
 import { MemberData } from "members";
+
 import { Induction, InductionStatus } from "./interfaces";
 
 const INDUCTION_EXPIRATION_DAYS = 7;
@@ -23,7 +26,7 @@ export const convertPendingProfileToMemberData = (
 export const getInductionStatus = (induction?: Induction) => {
     if (!induction) return InductionStatus.invalid;
 
-    const isExpired = dayjs(induction.created_at)
+    const isExpired = dayjs(eosBlockTimestampISO(induction.created_at))
         .add(INDUCTION_EXPIRATION_DAYS, "day")
         .isBefore(dayjs());
 
@@ -39,10 +42,9 @@ export const getInductionStatus = (induction?: Induction) => {
 export const getInductionRemainingTimeDays = (induction?: Induction) => {
     if (!induction) return "";
 
-    const remainingTimeObj = dayjs(induction.created_at).add(
-        INDUCTION_EXPIRATION_DAYS,
-        "day"
-    );
+    const remainingTimeObj = dayjs(
+        eosBlockTimestampISO(induction.created_at)
+    ).add(INDUCTION_EXPIRATION_DAYS, "day");
 
     const isExpired = induction && remainingTimeObj.isBefore(dayjs());
 


### PR DESCRIPTION
The timestamp returned from eos rpc does not respect ISO, which should add "Z" in the end to indicate that the time is UTC.

Original bug report:
![image](https://user-images.githubusercontent.com/79721020/119143636-d37a0180-ba15-11eb-810f-e3a97a9ca502.png)
