### PR TITLE
🐛 Stale data on endorse after sign out and back in

### DIFF
--- a/packages/webapp/src/pages/induction/[id].tsx
+++ b/packages/webapp/src/pages/induction/[id].tsx
@@ -6,6 +6,7 @@ import {
     RawLayout,
     SingleColLayout,
     useIsCommunityActive,
+    useUALAccount,
 } from "_app";
 import {
     getInductionStatus,
@@ -17,6 +18,9 @@ import {
 export const InductionDetailsPage = () => {
     const router = useRouter();
     const inductionId = router.query.id;
+
+    // refetches inductions query on sign in (in case previously cleared on sign out)
+    useUALAccount(); // see https://github.com/eoscommunity/Eden/pull/239
 
     const { isLoading: isLoadingCommunityState } = useIsCommunityActive();
 


### PR DESCRIPTION
While testing the induction journey as an endorser, I noticed that sometimes, my endorsement just kept spinning after signing and broadcasting the `inductendorse` action. Here's what was happening:

If I was signed in as one user and, while on the endorsements page, signed out and back in as another user to carry out the next endorsement, this would happen. (This will happen even if you sign out and back in as the _same_ user.)

It's because signing out clears the QueryCache, and the form submit handler for the endorsement form (and other forms in the induction journey) forces a refetch and re-render by invalidating the existing induction/endorsements query. BUT...signing out clears those queries entirely from the QueryCache, so there's nothing to refetch!

Simply calling the `useUALAccount` hook ensures that a refetch takes place in the induction journey when the user signs out and signs in. The query will always be established and present to be refetched when invalidated.