### PR TITLE
Automate closing finished auctions as part of gc

### DIFF
--- a/contracts/eden/CMakeLists.txt
+++ b/contracts/eden/CMakeLists.txt
@@ -6,11 +6,14 @@ add_executable(eden
    src/actions/genesis.cpp
    src/actions/induct.cpp
    src/actions/notify_assets.cpp
+   src/actions/migrate.cpp
    src/eden.cpp
    src/accounts.cpp
    src/globals.cpp
    src/inductions.cpp
    src/members.cpp
+   src/auctions.cpp
+   src/migrations.cpp
    src/atomicassets.cpp
 )
 target_include_directories(eden PUBLIC include ../token/include PRIVATE ../../external/atomicassets-contract/include)

--- a/contracts/eden/include/auctions.hpp
+++ b/contracts/eden/include/auctions.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <constants.hpp>
+#include <eosio/multi_index.hpp>
+#include <eosio/time.hpp>
+#include <globals.hpp>
+
+namespace eden
+{
+   struct migrate_auction_v0
+   {
+      uint64_t last_auction_id = 0;
+      uint32_t migrate_some(eosio::name contract, uint32_t max_steps);
+   };
+   EOSIO_REFLECT(migrate_auction_v0, last_auction_id);
+
+   // All active auctions
+   struct auction
+   {
+      uint64_t asset_id;
+      eosio::time_point_sec last_known_end_time;
+      uint64_t primary_key() const { return asset_id; }
+      uint64_t by_end_time() const { return last_known_end_time.sec_since_epoch(); }
+   };
+   EOSIO_REFLECT(auction, asset_id, last_known_end_time);
+   using auction_table_type = eosio::multi_index<
+       "auctions"_n,
+       auction,
+       eosio::indexed_by<"bytime"_n,
+                         eosio::const_mem_fun<auction, uint64_t, &auction::by_end_time>>>;
+
+   class auctions
+   {
+     private:
+      eosio::name contract;
+      auction_table_type auction_tb;
+      globals globals;
+
+     public:
+      explicit auctions(eosio::name contract)
+          : contract(contract), auction_tb(contract, default_scope), globals(contract)
+      {
+      }
+      void add_auction(uint64_t asset_id);
+      void add_auction(uint64_t asset_id, uint32_t end_time);
+      bool has_auction(uint64_t auction_id);
+      uint32_t finish_auctions(uint32_t);
+      void clear_all();
+   };
+}  // namespace eden

--- a/contracts/eden/include/auctions.hpp
+++ b/contracts/eden/include/auctions.hpp
@@ -4,6 +4,7 @@
 #include <eosio/multi_index.hpp>
 #include <eosio/time.hpp>
 #include <globals.hpp>
+#include <utils.hpp>
 
 namespace eden
 {
@@ -15,16 +16,27 @@ namespace eden
    EOSIO_REFLECT(migrate_auction_v0, last_auction_id);
 
    // All active auctions
-   struct auction
+   struct auction_v0
    {
       uint64_t asset_id;
       eosio::time_point_sec last_known_end_time;
       uint64_t primary_key() const { return asset_id; }
       uint64_t by_end_time() const { return last_known_end_time.sec_since_epoch(); }
    };
-   EOSIO_REFLECT(auction, asset_id, last_known_end_time);
+   EOSIO_REFLECT(auction_v0, asset_id, last_known_end_time);
+
+   using auction_variant = std::variant<auction_v0>;
+
+   struct auction
+   {
+      auction_variant value;
+      EDEN_FORWARD_MEMBERS(value, asset_id, last_known_end_time);
+      EDEN_FORWARD_FUNCTIONS(value, primary_key, by_end_time);
+   };
+   EOSIO_REFLECT(auction, value);
+
    using auction_table_type = eosio::multi_index<
-       "auctions"_n,
+       "auction"_n,
        auction,
        eosio::indexed_by<"bytime"_n,
                          eosio::const_mem_fun<auction, uint64_t, &auction::by_end_time>>>;

--- a/contracts/eden/include/eden.hpp
+++ b/contracts/eden/include/eden.hpp
@@ -76,6 +76,12 @@ namespace eden
 
       void gc(uint32_t limit);
 
+      // Update contract tables to the latest version of the contract, where necessary.
+      // New functionality may be unavailable until this is complete.
+      void migrate(uint32_t limit);
+      // For testing only.
+      void unmigrate();
+
       void notify_lognewtempl(int32_t template_id,
                               eosio::name authorized_creator,
                               eosio::name collection_name,
@@ -131,6 +137,8 @@ namespace eden
        action(inductcancel, account, id, ricardian_contract(inductcancel_ricardian)),
        action(inducted, inductee, ricardian_contract(inducted_ricardian)),
        action(gc, limit, ricardian_contract(gc_ricardian)),
+       action(migrate, limit),
+       action(unmigrate),
        notify(token_contract, transfer),
        notify(atomic_assets_account, lognewtempl),
        notify(atomic_assets_account, logmint))

--- a/contracts/eden/include/migrations.hpp
+++ b/contracts/eden/include/migrations.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <eosio/name.hpp>
+
+namespace eden
+{
+   class migrations
+   {
+     private:
+      eosio::name contract;
+
+     public:
+      migrations(eosio::name contract) : contract(contract) {}
+      void init();
+      void clear_all();
+      uint32_t migrate_some(uint32_t max_steps);
+   };
+}  // namespace eden

--- a/contracts/eden/include/migrations.hpp
+++ b/contracts/eden/include/migrations.hpp
@@ -1,9 +1,23 @@
 #pragma once
 
+#include <auctions.hpp>
 #include <eosio/name.hpp>
+#include <eosio/singleton.hpp>
+#include <variant>
 
 namespace eden
 {
+   // A specialization of this should always be the last type in the variant.
+   template <int N>
+   struct no_migration
+   {
+      uint32_t migrate_some(eosio::name contract, uint32_t max_steps) { return max_steps; }
+   };
+   EOSIO_REFLECT(no_migration<0>);
+   using migration_variant = std::variant<migrate_auction_v0, no_migration<0>>;
+
+   using migration_singleton = eosio::singleton<"migration"_n, migration_variant>;
+
    class migrations
    {
      private:

--- a/contracts/eden/src/actions/genesis.cpp
+++ b/contracts/eden/src/actions/genesis.cpp
@@ -1,9 +1,11 @@
 #include <accounts.hpp>
+#include <auctions.hpp>
 #include <eden-atomicassets.hpp>
 #include <eden.hpp>
 #include <globals.hpp>
 #include <inductions.hpp>
 #include <members.hpp>
+#include <migrations.hpp>
 
 namespace eden
 {
@@ -13,6 +15,8 @@ namespace eden
       accounts{get_self()}.clear_all();
       members{get_self()}.clear_all();
       inductions{get_self()}.clear_all();
+      auctions{get_self()}.clear_all();
+      migrations{get_self()}.clear_all();
       get_global_singleton(get_self()).remove();
    }
 
@@ -97,6 +101,8 @@ namespace eden
 
       eosio::check(community_symbol == auction_starting_bid.symbol,
                    "community symbol does not match auction starting bid");
+
+      migrations{get_self()}.init();
 
       globals{get_self(),
               {.community = community,

--- a/contracts/eden/src/actions/induct.cpp
+++ b/contracts/eden/src/actions/induct.cpp
@@ -1,4 +1,5 @@
 #include <accounts.hpp>
+#include <auctions.hpp>
 #include <eden.hpp>
 #include <inductions.hpp>
 #include <members.hpp>
@@ -113,7 +114,13 @@ namespace eden
    {
       inductions inductions{get_self()};
       std::vector<eosio::name> removed_members;
-      eosio::check(inductions.gc(limit, removed_members) != limit, "Nothing to do.");
+      auto remaining = inductions.gc(limit, removed_members);
+      if (remaining)
+      {
+         auctions auctions{get_self()};
+         remaining = auctions.finish_auctions(remaining);
+      }
+      eosio::check(remaining != limit, "Nothing to do.");
       if (!removed_members.empty())
       {
          members members(get_self());

--- a/contracts/eden/src/actions/migrate.cpp
+++ b/contracts/eden/src/actions/migrate.cpp
@@ -1,0 +1,18 @@
+#include <auctions.hpp>
+#include <eden.hpp>
+#include <migrations.hpp>
+
+namespace eden
+{
+   void eden::migrate(uint32_t max_steps)
+   {
+      eosio::check(migrations{get_self()}.migrate_some(max_steps) != max_steps, "Nothing to do");
+   }
+
+   void eden::unmigrate()
+   {
+      eosio::require_auth(get_self());
+      migrations{get_self()}.clear_all();
+      auctions{get_self()}.clear_all();
+   }
+}  // namespace eden

--- a/contracts/eden/src/actions/notify_assets.cpp
+++ b/contracts/eden/src/actions/notify_assets.cpp
@@ -1,3 +1,4 @@
+#include <auctions.hpp>
 #include <eden.hpp>
 #include <inductions.hpp>
 #include <members.hpp>
@@ -52,5 +53,7 @@ namespace eden
       inductions inductions{get_self()};
       const auto& induction = inductions.get_endorsed_induction(eosio::name(invitee));
       inductions.start_auction(induction, asset_id);
+      auctions auctions{get_self()};
+      auctions.add_auction(asset_id);
    }
 }  // namespace eden

--- a/contracts/eden/src/auctions.cpp
+++ b/contracts/eden/src/auctions.cpp
@@ -1,0 +1,178 @@
+#include <auctions.hpp>
+#include <eosio/crypto.hpp>
+#include <eosio/system.hpp>
+
+namespace eden
+{
+   namespace atomicmarket
+   {
+      struct auction
+      {
+         uint64_t auction_id;
+         eosio::name seller;
+         std::vector<uint64_t> asset_ids;
+         uint32_t end_time;
+         bool assets_transferred;
+         eosio::asset current_bid;
+         eosio::name current_bidder;
+         bool claimed_by_seller;
+         bool claimed_by_buyer;
+         eosio::name maker_marketplace;
+         eosio::name taker_marketplace;
+         eosio::name collection_name;
+         double collection_fee;
+
+         uint64_t primary_key() const { return auction_id; };
+
+         eosio::checksum256 by_assets() const;
+      };
+      EOSIO_REFLECT(auction,
+                    auction_id,
+                    seller,
+                    asset_ids,
+                    end_time,
+                    assets_transferred,
+                    current_bid,
+                    current_bidder,
+                    claimed_by_seller,
+                    claimed_by_buyer,
+                    maker_marketplace,
+                    taker_marketplace,
+                    collection_name,
+                    collection_fee);
+
+      using auction_table_type = eosio::multi_index<
+          "auctions"_n,
+          auction,
+          eosio::indexed_by<"byassets"_n,
+                            eosio::const_mem_fun<auction, eosio::checksum256, &auction::by_assets>>>;
+   }  // namespace atomicmarket
+
+   void auctions::add_auction(uint64_t asset_id)
+   {
+      auction_tb.emplace(contract, [&](auto& row) {
+         row.asset_id = asset_id;
+         row.last_known_end_time =
+             eosio::current_time_point() + eosio::seconds(globals.get().auction_duration);
+      });
+   }
+
+   void auctions::add_auction(uint64_t asset_id, uint32_t end_time)
+   {
+      auction_tb.emplace(contract, [&](auto& row) {
+         row.asset_id = asset_id;
+         row.last_known_end_time = eosio::time_point_sec{end_time};
+      });
+   }
+
+   bool auctions::has_auction(uint64_t asset_id)
+   {
+      return auction_tb.find(asset_id) != auction_tb.end();
+   }
+
+   uint32_t auctions::finish_auctions(uint32_t max_steps)
+   {
+      atomicmarket::auction_table_type market_tb(atomic_market_account,
+                                                 atomic_market_account.value);
+      const auto& asset_id_idx = market_tb.get_index<"byassets"_n>();
+
+      const auto& end_time_idx = auction_tb.get_index<"bytime"_n>();
+      auto iter = end_time_idx.begin();
+      auto end = end_time_idx.end();
+      eosio::time_point_sec current_time = eosio::current_time_point();
+      for (; max_steps > 0 && iter != end && iter->last_known_end_time < current_time; --max_steps)
+      {
+         const auto& auction = *iter++;
+         // Find the auction in atomicmarket if it exists.  There may be multiple auction rows
+         // with these assets, as the asset can be reauctioned before we claim the funds.
+         // We can distinguish the right auction by seller.
+         auto key = eosio::sha256(reinterpret_cast<const char*>(&auction.asset_id),
+                                  sizeof(auction.asset_id));
+         auto market_iter = asset_id_idx.lower_bound(key);
+         while (true)
+         {
+            if (market_iter->asset_ids.size() != 1 ||
+                market_iter->asset_ids.front() != auction.asset_id)
+            {
+               market_iter = asset_id_idx.end();
+               break;
+            }
+            if (market_iter->seller == contract)
+            {
+               break;
+            }
+            ++market_iter;
+         }
+         if (market_iter == asset_id_idx.end() || market_iter->claimed_by_seller)
+         {
+            auction_tb.erase(auction);
+         }
+         else
+         {
+            if (market_iter->end_time < current_time.sec_since_epoch())
+            {
+               if (market_iter->current_bidder != eosio::name())
+               {
+                  eosio::action{{contract, "active"_n},
+                                atomic_market_account,
+                                "auctclaimsel"_n,
+                                market_iter->auction_id}
+                      .send();
+               }
+               else
+               {
+                  eosio::action{{contract, "active"_n},
+                                atomic_market_account,
+                                "cancelauct"_n,
+                                market_iter->auction_id}
+                      .send();
+                  eosio::action{{contract, "active"_n},
+                                atomic_assets_account,
+                                "burnasset"_n,
+                                std::tuple(contract, auction.asset_id)};
+               }
+               auction_tb.erase(auction);
+            }
+            else
+            {
+               auction_tb.modify(auction, contract, [&](auto& row) {
+                  row.last_known_end_time = eosio::time_point_sec(market_iter->end_time);
+               });
+            }
+         }
+      }
+      return max_steps;
+   }
+
+   uint32_t migrate_auction_v0::migrate_some(eosio::name contract, uint32_t max_steps)
+   {
+      auctions auctions(contract);
+      atomicmarket::auction_table_type auction_tb(atomic_market_account,
+                                                  atomic_market_account.value);
+      for (auto iter = auction_tb.upper_bound(last_auction_id), end = auction_tb.end();
+           max_steps > 0 && iter != end; ++iter, --max_steps)
+      {
+         if (iter->seller == contract && iter->asset_ids.size() == 1)
+         {
+            auto asset_id = iter->asset_ids.front();
+            if (!auctions.has_auction(asset_id))
+            {
+               auctions.add_auction(asset_id, iter->end_time);
+            }
+         }
+         last_auction_id = iter->auction_id;
+      }
+      return max_steps;
+   }
+
+   void auctions::clear_all()
+   {
+      auto iter = auction_tb.begin();
+      auto end = auction_tb.end();
+      while (iter != end)
+      {
+         iter = auction_tb.erase(iter);
+      }
+   }
+
+}  // namespace eden

--- a/contracts/eden/src/eden.cpp
+++ b/contracts/eden/src/eden.cpp
@@ -1,7 +1,9 @@
 #include <accounts.hpp>
+#include <auctions.hpp>
 #include <eden.hpp>
 #include <inductions.hpp>
 #include <members.hpp>
+#include <migrations.hpp>
 
 EOSIO_ACTION_DISPATCHER(eden::actions)
 EOSIO_ABIGEN(
@@ -33,10 +35,12 @@ EOSIO_ABIGEN(
             "STRING_VEC"),
     actions(eden::actions),
     table("account"_n, eden::account_variant),
+    table("auction"_n, eden::auction_variant),
     table("endorsement"_n, eden::endorsement_variant),
     table("global"_n, eden::global_variant),
     table("induction"_n, eden::induction_variant),
     table("member"_n, eden::member_variant),
     table("memberstats"_n, eden::member_stats_variant),
+    table("migration"_n, eden::migration_variant),
     ricardian_clause("peacetreaty", eden::peacetreaty_clause),
     ricardian_clause("bylaws", eden::bylaws_clause))

--- a/contracts/eden/src/migrations.cpp
+++ b/contracts/eden/src/migrations.cpp
@@ -8,16 +8,16 @@ namespace eden
    void migrations::init()
    {
       migration_singleton migration(contract, default_scope);
-      migration.set(
-          std::variant_alternative_t<std::variant_size_v<migration_variant> - 1, migration_variant>(),
-          contract);
+      migration.set(std::variant_alternative_t<std::variant_size_v<migration_variant> - 1,
+                                               migration_variant>(),
+                    contract);
    }
 
    uint32_t migrations::migrate_some(uint32_t max_steps)
    {
       migration_singleton migration(contract, default_scope);
       auto state = migration.get_or_default(migration_variant());
-      while (state.index() != std::variant_size_v<migration_variant> - 1)
+      while (max_steps > 0 && state.index() != std::variant_size_v<migration_variant> - 1)
       {
          std::visit(
              [&](auto& current_state) {

--- a/contracts/eden/src/migrations.cpp
+++ b/contracts/eden/src/migrations.cpp
@@ -1,0 +1,56 @@
+#include <auctions.hpp>
+#include <boost/mp11/algorithm.hpp>
+#include <eosio/singleton.hpp>
+#include <migrations.hpp>
+#include <variant>
+
+namespace eden
+{
+   // A specialization of this should always be the last type in the variant.
+   template <int N>
+   struct no_migration
+   {
+      uint32_t migrate_some(eosio::name contract, uint32_t max_steps) { return max_steps; }
+   };
+   EOSIO_REFLECT(no_migration<0>);
+   using migration_type = std::variant<migrate_auction_v0, no_migration<0>>;
+
+   using migration_singleton = eosio::singleton<"migration"_n, migration_type>;
+
+   void migrations::clear_all() { migration_singleton(contract, default_scope).remove(); }
+
+   void migrations::init()
+   {
+      migration_singleton migration(contract, default_scope);
+      migration.set(
+          std::variant_alternative_t<std::variant_size_v<migration_type> - 1, migration_type>(),
+          contract);
+   }
+
+   uint32_t migrations::migrate_some(uint32_t max_steps)
+   {
+      migration_singleton migration(contract, default_scope);
+      auto state = migration.get_or_default(migration_type());
+      while (state.index() != std::variant_size_v<migration_type> - 1)
+      {
+         std::visit(
+             [&](auto& current_state) {
+                max_steps = current_state.migrate_some(contract, max_steps);
+                if (max_steps)
+                {
+                   constexpr std::size_t next_index =
+                       boost::mp11::mp_find<migration_type,
+                                            std::decay_t<decltype(current_state)>>::value +
+                       1;
+                   if constexpr (next_index < std::variant_size_v<migration_type>)
+                   {
+                      state.emplace<next_index>();
+                   }
+                }
+             },
+             state);
+      }
+      migration.set(state, contract);
+      return max_steps;
+   }
+}  // namespace eden

--- a/contracts/eden/tests/test-eden.cpp
+++ b/contracts/eden/tests/test-eden.cpp
@@ -567,7 +567,16 @@ TEST_CASE("auction migration")
    t.ahab.act<atomicmarket::actions::auctclaimbuy>(1);
    auto old_balance = get_token_balance("eden.gm"_n);
    expect(t.eden_gm.trace<actions::gc>(42), "Nothing to do");
-   t.eden_gm.act<actions::migrate>(128);
+   while (true)
+   {
+      t.chain.start_block();
+      auto trace = t.eden_gm.trace<actions::migrate>(1);
+      if (trace.except)
+      {
+         expect(trace, "Nothing to do");
+         break;
+      }
+   }
    t.eden_gm.act<actions::gc>(42);
    auto new_balance = get_token_balance("eden.gm"_n);
    // 0.5 EOS left deposited in atomicmarket

--- a/libraries/eosiolib/CMakeLists.txt
+++ b/libraries/eosiolib/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_options(eosio-contract-base PUBLIC
     -Wl,--stack-first
     -Wl,--entry,apply
     -Wl,-z,stack-size=8192
+    -Wl,--no-merge-data-segments
     $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-Wl,--strip-all>
     -nostdlib
 )

--- a/libraries/eosiolib/tester/eosio/tester.hpp
+++ b/libraries/eosiolib/tester/eosio/tester.hpp
@@ -159,6 +159,7 @@ namespace eosio
 
    std::ostream& operator<<(std::ostream& os, const block_timestamp& obj);
    std::ostream& operator<<(std::ostream& os, const name& obj);
+   std::ostream& operator<<(std::ostream& os, const asset& obj);
 
    class test_rodeos;
 

--- a/libraries/eosiolib/tester/tester.cpp
+++ b/libraries/eosiolib/tester/tester.cpp
@@ -244,6 +244,11 @@ std::ostream& eosio::operator<<(std::ostream& os, const name& obj)
    return os << obj.to_string();
 }
 
+std::ostream& eosio::operator<<(std::ostream& os, const asset& obj)
+{
+   return os << obj.to_string();
+}
+
 const eosio::public_key eosio::test_chain::default_pub_key =
     public_key_from_string("EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV");
 const eosio::private_key eosio::test_chain::default_priv_key =


### PR DESCRIPTION
- If there are no bids, the assets will be burned
- A new migrate action sets up the tables required to track auctions that started before the new contract was deployed.
- The 5% collection fee is not claimed