### PR TITLE
readjust toaster position based on width

### DIFF
--- a/packages/webapp/src/_app/utils/error-handler.tsx
+++ b/packages/webapp/src/_app/utils/error-handler.tsx
@@ -1,4 +1,7 @@
-import toast from "react-hot-toast";
+import { useEffect } from "react";
+import useDimensions from "react-cool-dimensions";
+import toast, { Toaster as ReactHotToaster } from "react-hot-toast";
+
 import { HelpLink } from "_app/ui";
 
 export const onError = (error: Error, title = "") => {
@@ -65,5 +68,18 @@ const eosResourcesError = (message: string) => {
         {
             duration: 999_999_999,
         }
+    );
+};
+
+export const Toaster = () => {
+    const { observe, width } = useDimensions();
+    useEffect(() => observe(document.body), []);
+    return (
+        <ReactHotToaster
+            position="top-right"
+            toastOptions={{
+                style: { marginTop: width < 768 ? "144px" : "60px" },
+            }}
+        />
     );
 };

--- a/packages/webapp/src/pages/_app.tsx
+++ b/packages/webapp/src/pages/_app.tsx
@@ -4,13 +4,12 @@ import Router from "next/router";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Hydrate } from "react-query/hydration";
 import { ReactQueryDevtools } from "react-query/devtools";
-import { Toaster } from "react-hot-toast";
 import NProgress from "nprogress";
 import dayjs from "dayjs";
 import * as localizedFormat from "dayjs/plugin/localizedFormat";
 import * as relativeTime from "dayjs/plugin/relativeTime";
 
-import { EdenUALProvider } from "_app";
+import { EdenUALProvider, Toaster } from "_app";
 
 import "tailwindcss/tailwind.css";
 import "_app/styles/nprogress.tailwind.css";
@@ -39,14 +38,7 @@ const WebApp = ({ Component, pageProps }: AppProps) => {
                 </EdenUALProvider>
             </Hydrate>
             <ReactQueryDevtools initialIsOpen={false} />
-            <Toaster
-                position="top-right"
-                toastOptions={{
-                    style: {
-                        marginTop: "60px",
-                    },
-                }}
-            />
+            <Toaster />
         </QueryClientProvider>
     );
 };


### PR DESCRIPTION
fixes #230 

- I wasn't able to reproduce the toaster staying forever, it always  dismiss after a certain period (unless you hover over the mouse, which is not possible on mobile...)

I'm closing for now since it's repositioned to not conflict with the header menu.