### PR TITLE
Track donated funds

### DIFF
--- a/contracts/eden/include/eden.hpp
+++ b/contracts/eden/include/eden.hpp
@@ -42,6 +42,8 @@ namespace eden
 
       void withdraw(eosio::name owner, const eosio::asset& quantity);
 
+      void donate(eosio::name payer, const eosio::asset& quantity);
+
       void genesis(std::string community,
                    eosio::symbol community_symbol,
                    eosio::asset minimum_donation,
@@ -106,6 +108,7 @@ namespace eden
        eden,
        "eden.gm"_n,
        action(withdraw, owner, quantity, ricardian_contract(withdraw_ricardian)),
+       action(donate, owner, quantity),
        action(genesis,
               community,
               community_symbol,

--- a/contracts/eden/include/eden.hpp
+++ b/contracts/eden/include/eden.hpp
@@ -44,6 +44,8 @@ namespace eden
 
       void donate(eosio::name payer, const eosio::asset& quantity);
 
+      void transfer(eosio::name to, const eosio::asset& quantity, const std::string& memo);
+
       void genesis(std::string community,
                    eosio::symbol community_symbol,
                    eosio::asset minimum_donation,
@@ -109,6 +111,7 @@ namespace eden
        "eden.gm"_n,
        action(withdraw, owner, quantity, ricardian_contract(withdraw_ricardian)),
        action(donate, owner, quantity),
+       action(transfer, to, quantity, memo),
        action(genesis,
               community,
               community_symbol,

--- a/contracts/eden/include/migrations.hpp
+++ b/contracts/eden/include/migrations.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <accounts.hpp>
 #include <auctions.hpp>
+#include <boost/mp11/algorithm.hpp>
 #include <eosio/name.hpp>
 #include <eosio/singleton.hpp>
 #include <variant>
@@ -14,7 +16,7 @@ namespace eden
       uint32_t migrate_some(eosio::name contract, uint32_t max_steps) { return max_steps; }
    };
    EOSIO_REFLECT(no_migration<0>);
-   using migration_variant = std::variant<migrate_auction_v0, no_migration<0>>;
+   using migration_variant = std::variant<migrate_auction_v0, migrate_account_v0, no_migration<0>>;
 
    using migration_singleton = eosio::singleton<"migration"_n, migration_variant>;
 
@@ -22,11 +24,34 @@ namespace eden
    {
      private:
       eosio::name contract;
+      migration_singleton migration_sing;
 
      public:
-      migrations(eosio::name contract) : contract(contract) {}
+      migrations(eosio::name contract) : contract(contract), migration_sing(contract, default_scope)
+      {
+      }
       void init();
       void clear_all();
       uint32_t migrate_some(uint32_t max_steps);
+      template <typename T>
+      std::optional<T> get()
+      {
+         if (migration_sing.exists())
+         {
+            auto state = migration_sing.get();
+            if (auto* result = std::get_if<T>(&state))
+            {
+               return *result;
+            }
+         }
+         return {};
+      }
+      void set(const migration_variant& new_value);
+      template <typename T>
+      bool is_completed()
+      {
+         return migration_sing.exists() &&
+                migration_sing.get().index() > boost::mp11::mp_find<migration_variant, T>::value;
+      }
    };
 }  // namespace eden

--- a/contracts/eden/src/accounts.cpp
+++ b/contracts/eden/src/accounts.cpp
@@ -1,7 +1,62 @@
 #include <accounts.hpp>
+#include <token/token.hpp>
 
 namespace eden
 {
+   uint32_t migrate_account_v0::migrate_some(eosio::name contract, uint32_t max_steps)
+   {
+      account_table_type user_tb(contract, default_scope);
+      if (user_total.symbol == eosio::symbol())
+      {
+         user_total = eosio::asset{0, globals{contract}.default_token()};
+      }
+      bool done = false;
+      for (auto iter = user_tb.upper_bound(last_visited.value), end = user_tb.end(); max_steps > 0;
+           ++iter, --max_steps)
+      {
+         if (iter == end)
+         {
+            done = true;
+            break;
+         }
+         user_total += iter->balance();
+         last_visited = iter->owner();
+      }
+      if (done)
+      {
+         account_table_type system_tb(contract, "owned"_n.value);
+         auto total_balance = token::contract::get_balance(
+             token_contract, contract, globals{contract}.default_token().code());
+         eosio::check(total_balance >= user_total,
+                      "Invariant failure: not enough funds to cover user balances");
+         if (total_balance != user_total)
+         {
+            auto iter = system_tb.find("master"_n.value);
+            if (iter == system_tb.end())
+            {
+               system_tb.emplace(contract, [&](auto& row) {
+                  row.value =
+                      account_v0{.owner = "master"_n, .balance = total_balance - user_total};
+               });
+               --max_steps;
+            }
+            else
+            {
+               eosio::check(iter->balance() == total_balance - user_total, "Incorrect balance");
+            }
+         }
+      }
+      return max_steps;
+   }
+
+   void migrate_account_v0::adjust_balance(eosio::name owner, eosio::asset amount)
+   {
+      if (owner <= last_visited)
+      {
+         user_total += amount;
+      }
+   }
+
    std::optional<account> accounts::get_account(eosio::name owner)
    {
       auto record = account_tb.find(owner.value);
@@ -16,8 +71,9 @@ namespace eden
       if (record == account_tb.end())
       {
          // TODO: create another global
-         eosio::check(quantity >= globals.get().minimum_donation,
-                      "insufficient deposit to open an account");
+         eosio::check(
+             account_tb.get_scope() != default_scope || quantity >= globals.get().minimum_donation,
+             "insufficient deposit to open an account");
          account_tb.emplace(
              contract, [&](auto& a) { a.value = account_v0{.owner = owner, .balance = quantity}; });
       }

--- a/contracts/eden/src/actions/accounts.cpp
+++ b/contracts/eden/src/actions/accounts.cpp
@@ -1,5 +1,6 @@
 #include <accounts.hpp>
 #include <eden.hpp>
+#include <migrations.hpp>
 #include <token/token.hpp>
 
 namespace eden
@@ -17,14 +18,34 @@ namespace eden
                               const eosio::asset& quantity,
                               std::string memo)
    {
-      if (to != get_self() || !is_possible_deposit_account(from))
+      if (from == get_self())
+      {
+         accounts{get_self(), "outgoing"_n}.sub_balance(to, quantity);
+         return;
+      }
+
+      if (to != get_self())
          return;
 
       globals globals{get_self()};
       eosio::check(quantity.symbol == globals.default_token(),
                    "token must be a valid " + globals.default_token().to_string());
 
-      accounts{get_self()}.add_balance(from, quantity);
+      migrations migrations{get_self()};
+
+      if (is_possible_deposit_account(from))
+      {
+         accounts{get_self()}.add_balance(from, quantity);
+         if (auto migration = migrations.get<migrate_account_v0>())
+         {
+            migration->adjust_balance(from, quantity);
+            migrations.set(*migration);
+         }
+      }
+      else if (migrations.is_completed<migrate_account_v0>())
+      {
+         accounts{get_self(), "owned"_n}.add_balance("master"_n, quantity);
+      }
    }
 
    void eden::withdraw(eosio::name owner, const eosio::asset& quantity)
@@ -36,7 +57,28 @@ namespace eden
                    "token must be a valid " + globals.default_token().to_string());
 
       accounts{get_self()}.sub_balance(owner, quantity);
+      migrations migrations{get_self()};
+      if (auto migration = migrations.get<migrate_account_v0>())
+      {
+         migration->adjust_balance(owner, -quantity);
+         migrations.set(*migration);
+      }
+      accounts{get_self(), "outgoing"_n}.add_balance(owner, quantity);
       token::actions::transfer{token_contract, get_self()}.send(  //
           get_self(), owner, quantity, "withdraw");
+   }
+
+   void eden::donate(eosio::name owner, const eosio::asset& quantity)
+   {
+      require_auth(owner);
+
+      globals globals{get_self()};
+      eosio::check(quantity.symbol == globals.default_token(),
+                   "token must be a valid " + globals.default_token().to_string());
+      eosio::check(quantity.amount > 0, "Donation must be positive");
+      eosio::check(migrations{get_self()}.is_completed<migrate_account_v0>(),
+                   "Tables must be migrated to enable donations");
+      accounts{get_self()}.sub_balance(owner, quantity);
+      accounts{get_self(), "owned"_n}.add_balance("master"_n, quantity);
    }
 }  // namespace eden

--- a/contracts/eden/src/actions/accounts.cpp
+++ b/contracts/eden/src/actions/accounts.cpp
@@ -48,6 +48,18 @@ namespace eden
       }
    }
 
+   void eden::transfer(eosio::name to, const eosio::asset& quantity, const std::string& memo)
+   {
+      require_auth(get_self());
+      accounts{get_self(), "owned"_n}.sub_balance("master"_n, quantity);
+      accounts{get_self(), "outgoing"_n}.add_balance(to, quantity);
+      eosio::action{{get_self(), "active"_n},
+                    token_contract,
+                    "transfer"_n,
+                    std::tuple(get_self(), to, quantity, memo)}
+          .send();
+   }
+
    void eden::withdraw(eosio::name owner, const eosio::asset& quantity)
    {
       require_auth(owner);

--- a/contracts/eden/src/actions/migrate.cpp
+++ b/contracts/eden/src/actions/migrate.cpp
@@ -14,5 +14,6 @@ namespace eden
       eosio::require_auth(get_self());
       migrations{get_self()}.clear_all();
       auctions{get_self()}.clear_all();
+      accounts{get_self(), "owned"_n}.clear_all();
    }
 }  // namespace eden

--- a/contracts/eden/tests/test-eden.cpp
+++ b/contracts/eden/tests/test-eden.cpp
@@ -773,6 +773,19 @@ TEST_CASE("deposit and spend")
    CHECK(get_token_balance("alice"_n) == s2a("1000.0000 EOS"));
 }
 
+TEST_CASE("accounting")
+{
+   eden_tester t;
+   t.genesis();
+   // should now have 30.0000 EOS, with a 90.0000 EOS deposit from alice
+   CHECK(get_token_balance("eden.gm"_n) == s2a("120.0000 EOS"));
+   expect(t.eden_gm.trace<actions::transfer>("eosio"_n, s2a("30.0001 EOS"), ""),
+          "insufficient balance");
+   t.eden_gm.act<actions::transfer>("eosio"_n, s2a("30.0000 EOS"), "");
+   CHECK(get_token_balance("eden.gm"_n) == s2a("90.0000 EOS"));
+   CHECK(get_token_balance("eosio"_n) == s2a("30.0000 EOS"));
+}
+
 TEST_CASE("account migration")
 {
    eden_tester t;

--- a/contracts/eden/tests/test-eden.cpp
+++ b/contracts/eden/tests/test-eden.cpp
@@ -496,8 +496,7 @@ TEST_CASE("induction")
               "alice"_n, 4, eosio::sha256(hash_data.data(), hash_data.size() - 1)),
           "Outdated endorsement");
 
-   auto endorse_all = [&]
-   {
+   auto endorse_all = [&] {
       t.alice.act<actions::inductendorse>("alice"_n, 4, induction_hash);
       t.pip.act<actions::inductendorse>("pip"_n, 4, induction_hash);
       t.egeon.act<actions::inductendorse>("egeon"_n, 4, induction_hash);
@@ -609,8 +608,7 @@ TEST_CASE("induction gc")
    }
 
    auto finish_induction = [&](uint64_t induction_id, eosio::name inviter, eosio::name invitee,
-                               const std::vector<eosio::name>& witnesses)
-   {
+                               const std::vector<eosio::name>& witnesses) {
       t.chain.as(invitee).act<token::actions::transfer>(invitee, "eden.gm"_n, s2a("10.0000 EOS"),
                                                         "memo");
 
@@ -773,4 +771,52 @@ TEST_CASE("deposit and spend")
    t.alice.act<actions::withdraw>("alice"_n, s2a("6.0000 EOS"));
    CHECK(get_eden_account("alice"_n) == std::nullopt);
    CHECK(get_token_balance("alice"_n) == s2a("1000.0000 EOS"));
+}
+
+TEST_CASE("account migration")
+{
+   eden_tester t;
+   t.genesis();
+   auto sum_accounts = [](eden::account_table_type& table) {
+      auto total = s2a("0.0000 EOS");
+      for (auto iter = table.begin(), end = table.end(); iter != end; ++iter)
+      {
+         CHECK(iter->balance().amount > 0);
+         total += iter->balance();
+      }
+      return total;
+   };
+
+   {
+      eden::account_table_type user_table{"eden.gm"_n, eden::default_scope};
+      eden::account_table_type system_table{"eden.gm"_n, "owned"_n.value};
+      CHECK(sum_accounts(user_table) + sum_accounts(system_table) ==
+            get_token_balance("eden.gm"_n));
+   }
+   t.eden_gm.act<actions::unmigrate>();
+   {
+      eden::account_table_type user_table{"eden.gm"_n, eden::default_scope};
+      eden::account_table_type system_table{"eden.gm"_n, "owned"_n.value};
+      CHECK(sum_accounts(system_table) == s2a("0.0000 EOS"));
+   }
+   expect(t.alice.trace<actions::donate>("alice"_n, s2a("0.4200 EOS")), "must be migrated");
+
+   while (true)
+   {
+      t.chain.start_block();
+      t.alice.act<token::actions::transfer>("alice"_n, "eden.gm"_n, s2a("15.0000 EOS"), "");
+      t.alice.act<actions::withdraw>("alice"_n, s2a("14.0000 EOS"));
+      auto trace = t.eden_gm.trace<actions::migrate>(1);
+      if (trace.except)
+      {
+         expect(trace, "Nothing to do");
+         break;
+      }
+   }
+   {
+      eden::account_table_type user_table{"eden.gm"_n, eden::default_scope};
+      eden::account_table_type system_table{"eden.gm"_n, "owned"_n.value};
+      CHECK(sum_accounts(user_table) + sum_accounts(system_table) ==
+            get_token_balance("eden.gm"_n));
+   }
 }


### PR DESCRIPTION
- Direct token transfers out of the contract are no longer allowed.  Transfers using donated funds must use the transfer action.
- There is now a plain `donate` action.