### PR TITLE
Rename blog to website on profile (form)

### DIFF
--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
@@ -198,7 +198,7 @@ export const InductionProfileForm = ({
                 />
             </Form.LabeledSet>
             <Form.LabeledSet
-                label="Personal blog URL"
+                label="Personal website"
                 htmlFor="blog"
                 className="col-span-6 md:col-span-3 lg:col-span-6 xl:col-span-3"
             >

--- a/packages/webapp/src/members/components/member-social-links.tsx
+++ b/packages/webapp/src/members/components/member-social-links.tsx
@@ -29,7 +29,7 @@ export const MemberSocialLinks = ({ member }: Props) => (
         )}
         {member.socialHandles.blog && (
             <SocialButton
-                handle="Blog"
+                handle="Website"
                 icon={HiOutlineLink}
                 href={urlify(member.socialHandles.blog)}
             />


### PR DESCRIPTION
Closes #127 

The word "blog" is a subset of "website." "Website" covers more of what people might put in that field. This is an easy way to close this ticket and get rid of that terminology dissonance.