### PR TITLE
Allow resignation

### DIFF
--- a/contracts/eden/include/eden.hpp
+++ b/contracts/eden/include/eden.hpp
@@ -78,6 +78,8 @@ namespace eden
 
       void inducted(eosio::name inductee);
 
+      void resign(eosio::name member);
+
       void gc(uint32_t limit);
 
       // Update contract tables to the latest version of the contract, where necessary.
@@ -142,6 +144,7 @@ namespace eden
        action(inductdonate, payer, id, quantity, ricardian_contract(inductdonate_ricardian)),
        action(inductcancel, account, id, ricardian_contract(inductcancel_ricardian)),
        action(inducted, inductee, ricardian_contract(inducted_ricardian)),
+       action(resign, account),
        action(gc, limit, ricardian_contract(gc_ricardian)),
        action(migrate, limit),
        action(unmigrate),

--- a/contracts/eden/include/members.hpp
+++ b/contracts/eden/include/members.hpp
@@ -71,6 +71,8 @@ namespace eden
       const member& get_member(eosio::name account);
       const member_table_type& get_table() const { return member_tb; }
       void create(eosio::name account);
+      member_table_type::const_iterator erase(member_table_type::const_iterator iter);
+      void remove(eosio::name account);
       void remove_if_pending(eosio::name account);
       bool is_new_member(eosio::name account) const;
       void check_active_member(eosio::name account);

--- a/contracts/eden/src/actions/induct.cpp
+++ b/contracts/eden/src/actions/induct.cpp
@@ -67,10 +67,13 @@ namespace eden
       inductions inductions{get_self()};
       const auto& induction = inductions.get_induction(id);
 
-      members{get_self()}.check_pending_member(induction.invitee());
+      members members{get_self()};
+      members.check_pending_member(induction.invitee());
 
       eosio::check(inductions.is_endorser(id, account),
                    "Induction can only be endorsed by inviter or a witness");
+      // The endorser might have resigned
+      members.check_active_member(account);
       inductions.endorse(induction, account, induction_data_hash);
    }
 
@@ -171,6 +174,14 @@ namespace eden
             members.maybe_activate_contract();
          }
       }
+   }
+
+   void eden::resign(eosio::name account)
+   {
+      eosio::require_auth(account);
+      members members{get_self()};
+      members.check_active_member(account);
+      members.remove(account);
    }
 
 }  // namespace eden

--- a/contracts/eden/src/members.cpp
+++ b/contracts/eden/src/members.cpp
@@ -38,6 +38,34 @@ namespace eden
       });
    }
 
+   member_table_type::const_iterator members::erase(member_table_type::const_iterator iter)
+   {
+      auto stats = this->stats();
+      switch (iter->status())
+      {
+         case member_status::pending_membership:
+            eosio::check(stats.pending_members != 0, "Integer overflow");
+            --stats.pending_members;
+            break;
+         case member_status::active_member:
+            eosio::check(stats.active_members != 0, "Integer overflow");
+            --stats.active_members;
+            break;
+         default:
+            eosio::check(false, "Invariant failure: unknown member status");
+            break;
+      }
+      member_stats.set(stats, contract);
+      return member_tb.erase(iter);
+   }
+
+   void members::remove(eosio::name account)
+   {
+      auto iter = member_tb.find(account.value);
+      eosio::check(iter != member_tb.end(), "Unknown member");
+      erase(iter);
+   }
+
    void members::remove_if_pending(eosio::name account)
    {
       const auto& member = member_tb.get(account.value);

--- a/contracts/eden/tests/test-eden.cpp
+++ b/contracts/eden/tests/test-eden.cpp
@@ -523,6 +523,14 @@ TEST_CASE("induction")
    CHECK(get_eden_membership("bertie"_n).status() == eden::member_status::active_member);
 }
 
+TEST_CASE("resignation")
+{
+   eden_tester t;
+   t.genesis();
+   t.alice.act<actions::resign>("alice"_n);
+   CHECK(members{"eden.gm"_n}.is_new_member("alice"_n));
+}
+
 TEST_CASE("auction")
 {
    eden_tester t;


### PR DESCRIPTION
- A member who resigns will be completely removed from the contract tables
- The contract does not (and cannot) burn existing NFTs.
- The member who resigned may not endorse inductions, but any endorsements made before resigning remain valid
