### PR TITLE
Profile Preview for Invitee Profile QA

### DIFF
--- a/packages/webapp/src/_app/ui/button.tsx
+++ b/packages/webapp/src/_app/ui/button.tsx
@@ -32,13 +32,15 @@ export type ButtonType =
     | "dangerOutline"
     | "inductionStatusProfile"
     | "inductionStatusCeremony"
-    | "inductionStatusAction";
+    | "inductionStatusAction"
+    | "link";
 const TYPES: { [key in ButtonType]: string } = {
     primary: "bg-blue-500 border-blue-500 text-white hover:bg-blue-600",
     disabled: "border-gray-400 bg-gray-300 text-gray-500",
     neutral: "bg-gray-50 text-gray-800 hover:bg-gray-200",
     danger: "bg-red-500 text-white hover:bg-red-600",
     dangerOutline: "text-gray-500 hover:text-red-500 border-none",
+    link: "border-transparent text-blue-500 hover:text-yellow-500",
     inductionStatusProfile:
         "bg-blue-500 border-blue-500 text-white hover:bg-blue-600",
     inductionStatusCeremony:

--- a/packages/webapp/src/inductions/components/induction-journeys/common/endorsements-status.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/common/endorsements-status.tsx
@@ -1,4 +1,4 @@
-import { Heading, Link, useMemberListByAccountNames } from "_app";
+import { Link, useMemberListByAccountNames } from "_app";
 import { Endorsement } from "inductions/interfaces";
 
 export const EndorsementsStatus = ({
@@ -29,22 +29,17 @@ export const EndorsementsStatus = ({
         );
 
     return (
-        <>
-            <Heading size={3} className="mb-2">
-                Endorsement status:
-            </Heading>
-            <ul className="mb-4 ml-2">
-                {endorsements.map((endorser) => (
-                    <li key={endorser.id}>
-                        {getEndorserStatus(endorser)}{" "}
-                        <Link href={`/members/${endorser.endorser}`}>
-                            <span className="text-gray-800 hover:underline">
-                                {getEndorserName(endorser)}
-                            </span>
-                        </Link>
-                    </li>
-                ))}
-            </ul>
-        </>
+        <ul className="mb-4 ml-2">
+            {endorsements.map((endorser) => (
+                <li key={endorser.id}>
+                    {getEndorserStatus(endorser)}{" "}
+                    <Link href={`/members/${endorser.endorser}`}>
+                        <span className="text-gray-800 hover:underline">
+                            {getEndorserName(endorser)}
+                        </span>
+                    </Link>
+                </li>
+            ))}
+        </ul>
     );
 };

--- a/packages/webapp/src/inductions/components/induction-journeys/common/induction-expires-in.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/common/induction-expires-in.tsx
@@ -3,7 +3,7 @@ import { getInductionRemainingTimeDays } from "inductions";
 import { Induction } from "inductions/interfaces";
 
 export const InductionExpiresIn = ({ induction }: { induction: Induction }) => (
-    <Text className="mb-6">
+    <Text className="mb-4">
         This invitation expires in {getInductionRemainingTimeDays(induction)}.
     </Text>
 );

--- a/packages/webapp/src/inductions/components/induction-journeys/common/member-card-preview.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/common/member-card-preview.tsx
@@ -2,11 +2,13 @@ import { Card } from "_app";
 import { MemberData, MemberHoloCard, MemberCard } from "members";
 
 export const MemberCardPreview = ({
+    cardTitle = "Invitee information",
     memberData,
 }: {
+    cardTitle?: string;
     memberData: MemberData;
 }) => (
-    <Card title="Invitee information" titleSize={2}>
+    <Card title={cardTitle} titleSize={2}>
         <div className="flex justify-center items-center space-y-10 xl:space-y-0 xl:space-x-10 flex-col xl:flex-row">
             <div className="max-w-xl">
                 <MemberHoloCard member={memberData} inducted={false} />

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee-journey.tsx
@@ -39,17 +39,17 @@ export const InviteeJourney = ({
     inductionStatus,
 }: Props) => {
     const [didSubmitProfile, setDidSubmitProfile] = useState(false);
-    const [isReviewingProfile, setIsReviewingProfile] = useState(false);
+    const [isRevisitingProfile, setIsRevisitingProfile] = useState(false);
 
     if (didSubmitProfile) {
         return <SubmittedProfileStep />;
     }
 
-    if (isReviewingProfile) {
+    if (isRevisitingProfile) {
         return (
             <ProfileStep
                 induction={induction}
-                isReviewingProfile={isReviewingProfile}
+                isRevisitingProfile={isRevisitingProfile}
                 setDidSubmitProfile={setDidSubmitProfile}
             />
         );
@@ -60,7 +60,7 @@ export const InviteeJourney = ({
             return (
                 <ProfileStep
                     induction={induction}
-                    isReviewingProfile={isReviewingProfile}
+                    isRevisitingProfile={isRevisitingProfile}
                     setDidSubmitProfile={setDidSubmitProfile}
                 />
             );
@@ -68,7 +68,7 @@ export const InviteeJourney = ({
             return (
                 <PendingCeremonyVideoStep
                     induction={induction}
-                    setIsReviewingProfile={setIsReviewingProfile}
+                    setIsRevisitingProfile={setIsRevisitingProfile}
                 />
             );
         case InductionStatus.PendingEndorsement: // not possible in Genesis mode
@@ -76,7 +76,7 @@ export const InviteeJourney = ({
                 <PendingEndorsementStep
                     induction={induction}
                     endorsements={endorsements}
-                    setIsReviewingProfile={setIsReviewingProfile}
+                    setIsRevisitingProfile={setIsRevisitingProfile}
                 />
             );
         case InductionStatus.PendingDonation:
@@ -84,7 +84,7 @@ export const InviteeJourney = ({
                 <PendingDonationStep
                     induction={induction}
                     endorsements={endorsements}
-                    setIsReviewingProfile={setIsReviewingProfile}
+                    setIsRevisitingProfile={setIsRevisitingProfile}
                 />
             );
         default:
@@ -128,13 +128,13 @@ const SubmittedProfileStep = () => {
 
 interface ProfileStepProps {
     induction: Induction;
-    isReviewingProfile: boolean;
+    isRevisitingProfile: boolean;
     setDidSubmitProfile: Dispatch<SetStateAction<boolean>>;
 }
 
 const ProfileStep = ({
     induction,
-    isReviewingProfile,
+    isRevisitingProfile,
     setDidSubmitProfile,
 }: ProfileStepProps) => {
     const { data: isCommunityActive } = useIsCommunityActive();
@@ -170,7 +170,7 @@ const ProfileStep = ({
         >
             <InductionProfileFormContainer
                 induction={induction}
-                isReviewingProfile={isReviewingProfile} // isRevisitingProfile? isEditingProfile?
+                isRevisitingProfile={isRevisitingProfile} // isRevisitingProfile? isEditingProfile?
                 pendingProfile={pendingProfile}
                 setProfilePreview={setProfilePreview}
             />
@@ -180,12 +180,12 @@ const ProfileStep = ({
 
 interface PendingCeremonyVideoStepProps {
     induction: Induction;
-    setIsReviewingProfile: Dispatch<SetStateAction<boolean>>;
+    setIsRevisitingProfile: Dispatch<SetStateAction<boolean>>;
 }
 
 const PendingCeremonyVideoStep = ({
     induction,
-    setIsReviewingProfile,
+    setIsRevisitingProfile,
 }: PendingCeremonyVideoStepProps) => {
     const memberData = convertPendingProfileToMemberData(
         induction.new_member_profile,
@@ -200,7 +200,7 @@ const PendingCeremonyVideoStep = ({
             <WaitingForVideo induction={induction} />
             <Text className="my-3">
                 If anything needs to be corrected,{" "}
-                <Link onClick={() => setIsReviewingProfile(true)}>
+                <Link onClick={() => setIsRevisitingProfile(true)}>
                     click here to make those adjustments.
                 </Link>
             </Text>
@@ -211,13 +211,13 @@ const PendingCeremonyVideoStep = ({
 interface PendingCompletionStepProps {
     induction: Induction;
     endorsements: Endorsement[];
-    setIsReviewingProfile: Dispatch<SetStateAction<boolean>>;
+    setIsRevisitingProfile: Dispatch<SetStateAction<boolean>>;
 }
 
 const PendingEndorsementStep = ({
     induction,
     endorsements,
-    setIsReviewingProfile,
+    setIsRevisitingProfile,
 }: PendingCompletionStepProps) => {
     const memberData = convertPendingProfileToMemberData(
         induction.new_member_profile,
@@ -239,7 +239,7 @@ const PendingEndorsementStep = ({
                 <Text>
                     Now is a good time to review your profile information below.
                     If anything needs to be corrected,{" "}
-                    <Link onClick={() => setIsReviewingProfile(true)}>
+                    <Link onClick={() => setIsRevisitingProfile(true)}>
                         click here to make those adjustments.
                     </Link>{" "}
                     Keep in mind that any modifications to your profile will
@@ -253,7 +253,7 @@ const PendingEndorsementStep = ({
 const PendingDonationStep = ({
     induction,
     endorsements,
-    setIsReviewingProfile,
+    setIsRevisitingProfile,
 }: PendingCompletionStepProps) => {
     const memberData = convertPendingProfileToMemberData(
         induction.new_member_profile,
@@ -280,7 +280,7 @@ const PendingDonationStep = ({
             <InductionDonateForm
                 induction={induction}
                 isCommunityActive={isCommunityActive}
-                setIsReviewingProfile={setIsReviewingProfile}
+                setIsRevisitingProfile={setIsRevisitingProfile}
             />
         </Container>
     );

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee-journey.tsx
@@ -1,10 +1,10 @@
 import React, { Dispatch, SetStateAction, useState } from "react";
 
 import { Heading, Link, Text, useIsCommunityActive } from "_app";
-import { convertPendingProfileToMemberData } from "inductions";
 import { MemberData } from "members";
 
 import {
+    convertPendingProfileToMemberData,
     EndorsementsStatus,
     InductionExpiresIn,
     InductionStepGenesis,
@@ -138,6 +138,7 @@ const ProfileStep = ({
     setDidSubmitProfile,
 }: ProfileStepProps) => {
     const { data: isCommunityActive } = useIsCommunityActive();
+
     const [showPreview, setShowPreview] = useState<Boolean>(false);
     const [pendingProfile, setPendingProfile] = useState<{
         profileInfo?: NewMemberProfile;
@@ -155,7 +156,7 @@ const ProfileStep = ({
                 induction={induction}
                 setDidSubmitProfile={setDidSubmitProfile}
                 pendingProfile={pendingProfile}
-                showProfileForm={() => setShowPreview(false)}
+                editProfile={() => setShowPreview(false)}
             />
         );
     }
@@ -170,7 +171,7 @@ const ProfileStep = ({
         >
             <InductionProfileFormContainer
                 induction={induction}
-                isRevisitingProfile={isRevisitingProfile} // isRevisitingProfile? isEditingProfile?
+                isRevisitingProfile={isRevisitingProfile}
                 pendingProfile={pendingProfile}
                 setProfilePreview={setProfilePreview}
             />

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee-journey.tsx
@@ -139,33 +139,22 @@ const ProfileStep = ({
 }: ProfileStepProps) => {
     const { data: isCommunityActive } = useIsCommunityActive();
     const [showPreview, setShowPreview] = useState<Boolean>(false);
-    const [pendingProfile, setPendingProfile] = useState<
-        NewMemberProfile | undefined
-    >();
-    const [selectedProfilePhoto, setSelectedProfilePhoto] = useState<
-        File | undefined
-    >();
+    const [pendingProfile, setPendingProfile] = useState<{
+        profileInfo?: NewMemberProfile;
+        selectedPhoto?: File;
+    }>({});
 
-    const setProfilePreview = (
-        profileData: NewMemberProfile,
-        profilePhoto?: File
-    ) => {
-        setPendingProfile(profileData);
-        setSelectedProfilePhoto(profilePhoto);
+    const setProfilePreview = (profile: NewMemberProfile, photo?: File) => {
+        setPendingProfile({ profileInfo: profile, selectedPhoto: photo });
         setShowPreview(true);
     };
 
-    // Move form submission logic into a profile preview component that's now in charge of submitting the transaction
-    // The form container and form will now only be in charge of hydrating the form state (if present) and passing it up to this ProfileStep component
-    // This component will pass it down, in turn, to the preview component and back ot the ProfileForm if user toggles back to make changes
-
-    if (showPreview && pendingProfile) {
+    if (showPreview && pendingProfile.profileInfo) {
         return (
             <InductionProfilePreview
                 induction={induction}
                 setDidSubmitProfile={setDidSubmitProfile}
-                newMemberProfile={pendingProfile}
-                selectedProfilePhoto={selectedProfilePhoto}
+                pendingProfile={pendingProfile}
                 showProfileForm={() => setShowPreview(false)}
             />
         );
@@ -183,7 +172,6 @@ const ProfileStep = ({
                 induction={induction}
                 isReviewingProfile={isReviewingProfile} // isRevisitingProfile? isEditingProfile?
                 pendingProfile={pendingProfile}
-                selectedProfilePhoto={selectedProfilePhoto}
                 setProfilePreview={setProfilePreview}
             />
         </Container>

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/donate-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/donate-form.tsx
@@ -20,13 +20,13 @@ import { Induction } from "inductions/interfaces";
 interface Props {
     induction: Induction;
     isCommunityActive?: boolean;
-    setIsReviewingProfile: (isReviewing: boolean) => void;
+    setIsRevisitingProfile: (isRevisiting: boolean) => void;
 }
 
 export const InductionDonateForm = ({
     induction,
     isCommunityActive,
-    setIsReviewingProfile,
+    setIsRevisitingProfile,
 }: Props) => {
     const router = useRouter();
     const queryClient = useQueryClient();
@@ -75,7 +75,7 @@ export const InductionDonateForm = ({
             <Text>
                 This is your last chance to review your profile below for
                 completeness and accuracy. If anything needs to be corrected,{" "}
-                <Link onClick={() => setIsReviewingProfile(true)}>
+                <Link onClick={() => setIsRevisitingProfile(true)}>
                     click here
                 </Link>
                 .

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/index.ts
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/index.ts
@@ -1,4 +1,5 @@
 export * from "./donate-form";
 export * from "./profile-form";
 export * from "./profile-form-container";
+export * from "./profile-preview";
 export * from "./profile-submit-confirmation";

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form-container.tsx
@@ -5,8 +5,10 @@ import { Induction, NewMemberProfile } from "inductions/interfaces";
 interface Props {
     induction: Induction;
     isReviewingProfile: boolean;
-    pendingProfile?: NewMemberProfile;
-    selectedProfilePhoto?: File;
+    pendingProfile: {
+        profileInfo?: NewMemberProfile;
+        selectedPhoto?: File;
+    };
     setProfilePreview: (
         profileData: NewMemberProfile,
         profilePhoto?: File
@@ -17,9 +19,9 @@ export const InductionProfileFormContainer = ({
     induction,
     isReviewingProfile,
     pendingProfile,
-    selectedProfilePhoto,
     setProfilePreview,
 }: Props) => {
+    const { profileInfo, selectedPhoto } = pendingProfile;
     return (
         <>
             <Heading size={1} className="mb-2">
@@ -29,11 +31,9 @@ export const InductionProfileFormContainer = ({
             </Heading>
             <InductionExpiresIn induction={induction} />
             <InductionProfileForm
-                newMemberProfile={
-                    pendingProfile || induction.new_member_profile
-                }
+                newMemberProfile={profileInfo || induction.new_member_profile}
                 onSubmit={setProfilePreview}
-                selectedProfilePhoto={selectedProfilePhoto}
+                selectedProfilePhoto={selectedPhoto}
             />
         </>
     );

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form-container.tsx
@@ -4,7 +4,7 @@ import { Induction, NewMemberProfile } from "inductions/interfaces";
 
 interface Props {
     induction: Induction;
-    isReviewingProfile: boolean;
+    isRevisitingProfile: boolean;
     pendingProfile: {
         profileInfo?: NewMemberProfile;
         selectedPhoto?: File;
@@ -17,7 +17,7 @@ interface Props {
 
 export const InductionProfileFormContainer = ({
     induction,
-    isReviewingProfile,
+    isRevisitingProfile,
     pendingProfile,
     setProfilePreview,
 }: Props) => {
@@ -25,7 +25,7 @@ export const InductionProfileFormContainer = ({
     return (
         <>
             <Heading size={1} className="mb-2">
-                {isReviewingProfile
+                {isRevisitingProfile
                     ? "Review your Eden profile"
                     : "Create your Eden profile"}
             </Heading>

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form-container.tsx
@@ -1,64 +1,25 @@
-import { Dispatch, SetStateAction } from "react";
-
-import {
-    Heading,
-    onError,
-    uploadIpfsFileWithTransaction,
-    uploadToIpfs,
-    useUALAccount,
-} from "_app";
-import {
-    InductionExpiresIn,
-    InductionProfileForm,
-    setInductionProfileTransaction,
-} from "inductions";
+import { Heading } from "_app";
+import { InductionExpiresIn, InductionProfileForm } from "inductions";
 import { Induction, NewMemberProfile } from "inductions/interfaces";
 
 interface Props {
     induction: Induction;
     isReviewingProfile: boolean;
-    setSubmittedProfile: Dispatch<SetStateAction<boolean>>;
+    pendingProfile?: NewMemberProfile;
+    selectedProfilePhoto?: File;
+    setProfilePreview: (
+        profileData: NewMemberProfile,
+        profilePhoto?: File
+    ) => void;
 }
 
 export const InductionProfileFormContainer = ({
     induction,
     isReviewingProfile,
-    setSubmittedProfile,
+    pendingProfile,
+    selectedProfilePhoto,
+    setProfilePreview,
 }: Props) => {
-    const [ualAccount] = useUALAccount();
-
-    const submitInductionProfileTransaction = async (
-        newMemberProfile: NewMemberProfile,
-        uploadedImage?: File
-    ) => {
-        try {
-            const img = uploadedImage
-                ? await uploadToIpfs(uploadedImage)
-                : newMemberProfile.img;
-
-            const authorizerAccount = ualAccount.accountName;
-            const transaction = setInductionProfileTransaction(
-                authorizerAccount,
-                induction.id,
-                { ...newMemberProfile, img }
-            );
-            console.info(transaction);
-
-            const signedTrx = await ualAccount.signTransaction(transaction, {
-                broadcast: !uploadedImage,
-            });
-            console.info("inductprofil trx", signedTrx);
-
-            if (uploadedImage) {
-                await uploadIpfsFileWithTransaction(signedTrx, img);
-            }
-
-            setSubmittedProfile(true);
-        } catch (error) {
-            onError(error, "Unable to set the profile");
-        }
-    };
-
     return (
         <>
             <Heading size={1} className="mb-2">
@@ -68,8 +29,11 @@ export const InductionProfileFormContainer = ({
             </Heading>
             <InductionExpiresIn induction={induction} />
             <InductionProfileForm
-                newMemberProfile={induction.new_member_profile}
-                onSubmit={submitInductionProfileTransaction}
+                newMemberProfile={
+                    pendingProfile || induction.new_member_profile
+                }
+                onSubmit={setProfilePreview}
+                selectedProfilePhoto={selectedProfilePhoto}
             />
         </>
     );

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
@@ -84,7 +84,11 @@ export const InductionProfileForm = ({
                 <Form.FileInput
                     id="imgFile"
                     accept="image/*"
-                    label="select an image file"
+                    label={
+                        selectedImage || fields.img
+                            ? "select a different image"
+                            : "select an image file"
+                    }
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                         handleFileChange(
                             e,
@@ -179,6 +183,7 @@ export const InductionProfileForm = ({
             >
                 <Form.Input
                     id="telegram"
+                    required
                     type="text"
                     value={socialFields.telegram}
                     onChange={onChangeSocialFields}
@@ -224,16 +229,6 @@ export const InductionProfileForm = ({
                     placeholder="YourUsername"
                 />
             </Form.LabeledSet>
-
-            <div className="col-span-6">
-                <Text>
-                    <span className="italic font-medium">Don't worry!</span>{" "}
-                    Even though you are committing your information to the
-                    blockchain right now, you will be able to review your
-                    profile and make changes to it all the way up until you
-                    complete your donation.
-                </Text>
-            </div>
 
             {onSubmit && (
                 <div className="col-span-6 pt-4">

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
@@ -15,27 +15,23 @@ import { NewMemberProfile } from "inductions";
 
 interface Props {
     newMemberProfile: NewMemberProfile;
-    disabled?: boolean;
     onSubmit?: (
         newMemberProfile: NewMemberProfile,
-        uploadedImage?: File
-    ) => Promise<void>;
+        selectedProfilePhoto?: File
+    ) => void;
+    selectedProfilePhoto?: File;
 }
 
 export const InductionProfileForm = ({
     newMemberProfile,
-    disabled,
     onSubmit,
+    selectedProfilePhoto,
 }: Props) => {
-    const [isLoading, setIsLoading] = useState(false);
-    const [consentsToPublish, setConsentsToPublish] = useState(false);
-
-    const [uploadedImage, setUploadedImage] = useState<File | undefined>(
-        undefined
+    const [selectedImage, setSelectedImage] = useState<File | undefined>(
+        selectedProfilePhoto
     );
 
     const [fields, setFields] = useFormFields({ ...newMemberProfile });
-
     const [socialFields, setSocialFields] = useFormFields(
         convertNewMemberProfileSocial(newMemberProfile.social)
     );
@@ -46,7 +42,7 @@ export const InductionProfileForm = ({
     const onChangeSocialFields = (e: React.ChangeEvent<HTMLInputElement>) =>
         setSocialFields(e);
 
-    const submitTransaction = async (e: FormEvent) => {
+    const prepareData = (e: FormEvent) => {
         e.preventDefault();
         if (!onSubmit) return;
 
@@ -56,16 +52,14 @@ export const InductionProfileForm = ({
             if (!socialHandles[key]) delete socialHandles[key];
         });
 
-        setIsLoading(true);
-        await onSubmit(
+        onSubmit(
             { ...fields, social: JSON.stringify(socialHandles) },
-            uploadedImage
+            selectedImage
         );
-        setIsLoading(false);
     };
 
     return (
-        <form onSubmit={submitTransaction} className="grid grid-cols-6 gap-4">
+        <form onSubmit={prepareData} className="grid grid-cols-6 gap-4">
             <Form.LabeledSet
                 label="Your name"
                 htmlFor="name"
@@ -75,7 +69,6 @@ export const InductionProfileForm = ({
                     id="name"
                     type="text"
                     required
-                    disabled={isLoading || disabled}
                     value={fields.name}
                     onChange={onChangeFields}
                 />
@@ -99,15 +92,15 @@ export const InductionProfileForm = ({
                             validUploadActions[edenContractAccount][
                                 "inductprofil"
                             ].maxSize,
-                            setUploadedImage
+                            setSelectedImage
                         )
                     }
                 />
-                {uploadedImage || fields.img ? (
+                {selectedImage || fields.img ? (
                     <img
                         src={
-                            uploadedImage
-                                ? URL.createObjectURL(uploadedImage)
+                            selectedImage
+                                ? URL.createObjectURL(selectedImage)
                                 : `https://ipfs.io/ipfs/${fields.img}`
                         }
                         alt="profile pic"
@@ -130,7 +123,6 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="attributions"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={fields.attributions}
                     onChange={onChangeFields}
                 />
@@ -144,7 +136,6 @@ export const InductionProfileForm = ({
                 <Form.TextArea
                     id="bio"
                     required
-                    disabled={isLoading || disabled}
                     value={fields.bio}
                     onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
                         setFields(e)
@@ -163,7 +154,6 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="eosCommunity"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={socialFields.eosCommunity}
                     onChange={onChangeSocialFields}
                     placeholder="YourUsername"
@@ -177,7 +167,6 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="twitter"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={socialFields.twitter}
                     onChange={onChangeSocialFields}
                     placeholder="YourHandle"
@@ -191,7 +180,6 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="telegram"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={socialFields.telegram}
                     onChange={onChangeSocialFields}
                     placeholder="YourHandle"
@@ -205,7 +193,6 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="blog"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={socialFields.blog}
                     onChange={onChangeSocialFields}
                     placeholder="yoursite.com"
@@ -219,7 +206,6 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="linkedin"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={socialFields.linkedin}
                     onChange={onChangeSocialFields}
                     placeholder="YourHandle"
@@ -233,21 +219,11 @@ export const InductionProfileForm = ({
                 <Form.Input
                     id="facebook"
                     type="text"
-                    disabled={isLoading || disabled}
                     value={socialFields.facebook}
                     onChange={onChangeSocialFields}
                     placeholder="YourUsername"
                 />
             </Form.LabeledSet>
-
-            <div className="col-span-6 p-3 border rounded-md">
-                <Form.Checkbox
-                    id="reviewed"
-                    label="I understand and acknowledge that I am publishing the profile information above permanently and irrevocably to an immutable, public blockchain. When I submit this form, it cannot be undone."
-                    value={Number(consentsToPublish)}
-                    onChange={() => setConsentsToPublish(!consentsToPublish)}
-                />
-            </div>
 
             <div className="col-span-6">
                 <Text>
@@ -261,13 +237,7 @@ export const InductionProfileForm = ({
 
             {onSubmit && (
                 <div className="col-span-6 pt-4">
-                    <Button
-                        isSubmit
-                        isLoading={isLoading}
-                        disabled={isLoading || !consentsToPublish}
-                    >
-                        {isLoading ? "Submitting..." : "Submit"}
-                    </Button>
+                    <Button isSubmit>Preview My Profile</Button>
                 </div>
             )}
         </form>

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
@@ -34,17 +34,6 @@ export const InductionProfilePreview = ({
     editProfile,
 }: Props) => {
     const [isLoading, setIsLoading] = useState(false);
-
-    const defaultAffirmations = {
-        image: false,
-        statement: false,
-        links: false,
-        handles: false,
-        consent: false,
-    };
-    const [affirmations, setAffirmations] = useState<
-        typeof defaultAffirmations
-    >(defaultAffirmations);
     const [ualAccount] = useUALAccount();
     const { profileInfo, selectedPhoto } = pendingProfile;
 
@@ -93,14 +82,6 @@ export const InductionProfilePreview = ({
         );
     }, [induction.invitee, profileInfo, selectedPhoto]);
 
-    const setAffirmation = (e: FormEvent) => {
-        const key = e.currentTarget.id as keyof typeof defaultAffirmations;
-        setAffirmations((prev) => ({
-            ...prev,
-            [key]: !prev[key],
-        }));
-    };
-
     return (
         <>
             <MemberCardPreview cardTitle="" memberData={memberCardData} />
@@ -111,59 +92,60 @@ export const InductionProfilePreview = ({
                 >
                     <div className="col-span-6">
                         <Text>
-                            Review your profile above for accuracy and
-                            compliance.
+                            Review your profile above as per the check boxes
+                            below. This is your first Eden community NFT and
+                            will be used by your fellow members to get to know
+                            you so please do your best to get it right.
                         </Text>
                     </div>
                     <div className="col-span-6 lg:col-span-3 p-3 border rounded">
                         <Form.Checkbox
                             id="image"
-                            label="My face is clearly visible and takes up most of the frame. I am not wearing a mask or sunglasses, and my likeness is otherwise unobstructed."
-                            onChange={setAffirmation}
-                            checked={affirmations["image"]}
+                            label="My face is clearly visible and is large enough that I can be easily identified as me. I'm not wearing a mask or sunglasses."
+                            disabled={isLoading}
+                            required
                         />
                     </div>
                     <div className="col-span-6 lg:col-span-3 p-3 border rounded">
                         <Form.Checkbox
                             id="statement"
-                            label="My profile statement is accurate and complete to the best of my knowledge. I have reviewed it for spelling and grammar mistakes."
-                            onChange={setAffirmation}
-                            checked={affirmations["statement"]}
+                            label="My profile statement is accurate and complete to the best of my knowledge."
+                            disabled={isLoading}
+                            required
                         />
                     </div>
                     <div className="col-span-6 lg:col-span-3 p-3 border rounded">
                         <Form.Checkbox
                             id="links"
                             label="I have clicked/tapped on each social link above and affirm that all links are working properly."
-                            onChange={setAffirmation}
-                            checked={affirmations["links"]}
+                            disabled={isLoading}
+                            required
                         />
                     </div>
                     <div className="col-span-6 lg:col-span-3 p-3 border rounded">
                         <Form.Checkbox
                             id="handles"
                             label="All social handles I have provided belong to me."
-                            onChange={setAffirmation}
-                            checked={affirmations["handles"]}
+                            disabled={isLoading}
+                            required
                         />
                     </div>
-                    <div className="col-span-6 p-3 border rounded-md">
+                    <div className="col-span-6 p-3 border rounded">
                         <Form.Checkbox
                             id="consent"
-                            label="I understand and acknowledge that by submitting my profile, I am publishing my information permanently and irrevocably to an immutable, public blockchain."
-                            onChange={setAffirmation}
-                            checked={affirmations["consent"]}
+                            label="I understand and acknowledge that by submitting my profile I am publishing my information permanently and irrevocably to an immutable, public blockchain."
+                            disabled={isLoading}
+                            required
                         />
                     </div>
                     <div className="flex col-span-6 pt-4 space-x-4 justify-center sm:justify-start">
-                        <Button onClick={editProfile}>Make Changes</Button>
+                        <Button onClick={editProfile} type="neutral">
+                            Make Changes
+                        </Button>
                         <Button
                             isSubmit
                             isLoading={isLoading}
-                            disabled={
-                                isLoading ||
-                                Object.values(affirmations).some((val) => !val)
-                            }
+                            disabled={isLoading}
                         >
                             {isLoading ? "Submitting..." : "Submit Profile"}
                         </Button>

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
@@ -1,0 +1,131 @@
+import { Dispatch, FormEvent, SetStateAction, useState } from "react";
+import {
+    Button,
+    Card,
+    Form,
+    onError,
+    Text,
+    uploadIpfsFileWithTransaction,
+    uploadToIpfs,
+    useUALAccount,
+} from "_app";
+import {
+    convertPendingProfileToMemberData,
+    MemberCardPreview,
+    setInductionProfileTransaction,
+} from "inductions";
+import { Induction, NewMemberProfile } from "inductions/interfaces";
+
+interface Props {
+    induction: Induction;
+    setDidSubmitProfile: Dispatch<SetStateAction<boolean>>;
+    newMemberProfile: NewMemberProfile;
+    selectedProfilePhoto?: File;
+    showProfileForm: () => void;
+}
+
+export const InductionProfilePreview = ({
+    induction,
+    setDidSubmitProfile,
+    newMemberProfile,
+    selectedProfilePhoto,
+    showProfileForm,
+}: Props) => {
+    const [isLoading, setIsLoading] = useState(false);
+    const [consentsToPublish, setConsentsToPublish] = useState(false);
+    const [ualAccount] = useUALAccount();
+
+    const submitInductionProfileTransaction = async (e: FormEvent) => {
+        e.preventDefault();
+        setIsLoading(true);
+        try {
+            const img = selectedProfilePhoto
+                ? await uploadToIpfs(selectedProfilePhoto)
+                : newMemberProfile.img;
+
+            const authorizerAccount = ualAccount.accountName;
+            const transaction = setInductionProfileTransaction(
+                authorizerAccount,
+                induction.id,
+                { ...newMemberProfile, img }
+            );
+            console.info(transaction);
+
+            const signedTrx = await ualAccount.signTransaction(transaction, {
+                broadcast: !selectedProfilePhoto,
+            });
+            console.info("inductprofil trx", signedTrx);
+
+            if (selectedProfilePhoto) {
+                await uploadIpfsFileWithTransaction(signedTrx, img);
+            }
+
+            setDidSubmitProfile(true);
+        } catch (error) {
+            onError(error, "Unable to set the profile");
+        }
+        setIsLoading(false);
+    };
+
+    const prepareMemberCard = () => {
+        // TODO: memoize
+        let pendingProfile = newMemberProfile;
+        if (selectedProfilePhoto) {
+            const img = URL.createObjectURL(selectedProfilePhoto);
+            console.log(img);
+            pendingProfile = { ...newMemberProfile, img };
+        }
+        return convertPendingProfileToMemberData(
+            pendingProfile,
+            induction.invitee
+        );
+    };
+
+    return (
+        <>
+            <MemberCardPreview memberData={prepareMemberCard()} />
+            <Card>
+                <form
+                    onSubmit={submitInductionProfileTransaction}
+                    className="grid grid-cols-6 gap-4"
+                >
+                    <div className="col-span-6 p-3 border rounded-md">
+                        <Form.Checkbox
+                            id="reviewed"
+                            label="I understand and acknowledge that I am publishing the profile information above permanently and irrevocably to an immutable, public blockchain. When I submit this form, it cannot be undone."
+                            value={Number(consentsToPublish)}
+                            onChange={() =>
+                                setConsentsToPublish(!consentsToPublish)
+                            }
+                        />
+                    </div>
+                    <div className="col-span-6">
+                        <Text>
+                            <span className="italic font-medium">
+                                Don't worry!
+                            </span>{" "}
+                            Even though you are committing your information to
+                            the blockchain right now, you will be able to review
+                            your profile and make changes to it all the way up
+                            until you complete your donation.
+                        </Text>
+                    </div>
+                    <div className="col-span-6 pt-4">
+                        <Button onClick={showProfileForm}>Make Changes</Button>
+                    </div>
+                    <div className="col-span-6 pt-4">
+                        <Button
+                            isSubmit
+                            isLoading={isLoading}
+                            disabled={isLoading || !consentsToPublish}
+                        >
+                            {isLoading ? "Submitting..." : "Submit"}
+                        </Button>
+                    </div>
+                </form>
+            </Card>
+        </>
+    );
+};
+
+export default InductionProfilePreview;

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
@@ -34,7 +34,17 @@ export const InductionProfilePreview = ({
     editProfile,
 }: Props) => {
     const [isLoading, setIsLoading] = useState(false);
-    const [consentsToPublish, setConsentsToPublish] = useState(false);
+
+    const defaultAffirmations = {
+        image: false,
+        statement: false,
+        links: false,
+        handles: false,
+        consent: false,
+    };
+    const [affirmations, setAffirmations] = useState<
+        typeof defaultAffirmations
+    >(defaultAffirmations);
     const [ualAccount] = useUALAccount();
     const { profileInfo, selectedPhoto } = pendingProfile;
 
@@ -83,45 +93,79 @@ export const InductionProfilePreview = ({
         );
     }, [induction.invitee, profileInfo, selectedPhoto]);
 
+    const setAffirmation = (e: FormEvent) => {
+        const key = e.currentTarget.id as keyof typeof defaultAffirmations;
+        setAffirmations((prev) => ({
+            ...prev,
+            [key]: !prev[key],
+        }));
+    };
+
     return (
         <>
-            <MemberCardPreview memberData={memberCardData} />
-            <Card>
+            <MemberCardPreview cardTitle="" memberData={memberCardData} />
+            <Card title="Review your profile">
                 <form
                     onSubmit={submitInductionProfileTransaction}
                     className="grid grid-cols-6 gap-4"
                 >
-                    <div className="col-span-6 p-3 border rounded-md">
-                        <Form.Checkbox
-                            id="reviewed"
-                            label="I understand and acknowledge that I am publishing the profile information above permanently and irrevocably to an immutable, public blockchain. When I submit this form, it cannot be undone."
-                            value={Number(consentsToPublish)}
-                            onChange={() =>
-                                setConsentsToPublish(!consentsToPublish)
-                            }
-                        />
-                    </div>
                     <div className="col-span-6">
                         <Text>
-                            <span className="italic font-medium">
-                                Don't worry!
-                            </span>{" "}
-                            Even though you are committing your information to
-                            the blockchain right now, you will be able to review
-                            your profile and make changes to it all the way up
-                            until you complete your donation.
+                            Review your profile above for accuracy and
+                            compliance.
                         </Text>
                     </div>
-                    <div className="col-span-6 pt-4">
-                        <Button onClick={editProfile}>Make Changes</Button>
+                    <div className="col-span-6 lg:col-span-3 p-3 border rounded">
+                        <Form.Checkbox
+                            id="image"
+                            label="My face is clearly visible and takes up most of the frame. I am not wearing a mask or sunglasses, and my likeness is otherwise unobstructed."
+                            onChange={setAffirmation}
+                            checked={affirmations["image"]}
+                        />
                     </div>
-                    <div className="col-span-6 pt-4">
+                    <div className="col-span-6 lg:col-span-3 p-3 border rounded">
+                        <Form.Checkbox
+                            id="statement"
+                            label="My profile statement is accurate and complete to the best of my knowledge. I have reviewed it for spelling and grammar mistakes."
+                            onChange={setAffirmation}
+                            checked={affirmations["statement"]}
+                        />
+                    </div>
+                    <div className="col-span-6 lg:col-span-3 p-3 border rounded">
+                        <Form.Checkbox
+                            id="links"
+                            label="I have clicked/tapped on each social link above and affirm that all links are working properly."
+                            onChange={setAffirmation}
+                            checked={affirmations["links"]}
+                        />
+                    </div>
+                    <div className="col-span-6 lg:col-span-3 p-3 border rounded">
+                        <Form.Checkbox
+                            id="handles"
+                            label="All social handles I have provided belong to me."
+                            onChange={setAffirmation}
+                            checked={affirmations["handles"]}
+                        />
+                    </div>
+                    <div className="col-span-6 p-3 border rounded-md">
+                        <Form.Checkbox
+                            id="consent"
+                            label="I understand and acknowledge that by submitting my profile, I am publishing my information permanently and irrevocably to an immutable, public blockchain."
+                            onChange={setAffirmation}
+                            checked={affirmations["consent"]}
+                        />
+                    </div>
+                    <div className="flex col-span-6 pt-4 space-x-4 justify-center sm:justify-start">
+                        <Button onClick={editProfile}>Make Changes</Button>
                         <Button
                             isSubmit
                             isLoading={isLoading}
-                            disabled={isLoading || !consentsToPublish}
+                            disabled={
+                                isLoading ||
+                                Object.values(affirmations).some((val) => !val)
+                            }
                         >
-                            {isLoading ? "Submitting..." : "Submit"}
+                            {isLoading ? "Submitting..." : "Submit Profile"}
                         </Button>
                     </div>
                 </form>

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
@@ -1,4 +1,5 @@
 import { Dispatch, FormEvent, SetStateAction, useMemo, useState } from "react";
+
 import {
     Button,
     Card,
@@ -23,14 +24,14 @@ interface Props {
         profileInfo?: NewMemberProfile;
         selectedPhoto?: File;
     };
-    showProfileForm: () => void;
+    editProfile: () => void;
 }
 
 export const InductionProfilePreview = ({
     induction,
     setDidSubmitProfile,
     pendingProfile,
-    showProfileForm,
+    editProfile,
 }: Props) => {
     const [isLoading, setIsLoading] = useState(false);
     const [consentsToPublish, setConsentsToPublish] = useState(false);
@@ -112,7 +113,7 @@ export const InductionProfilePreview = ({
                         </Text>
                     </div>
                     <div className="col-span-6 pt-4">
-                        <Button onClick={showProfileForm}>Make Changes</Button>
+                        <Button onClick={editProfile}>Make Changes</Button>
                     </div>
                     <div className="col-span-6 pt-4">
                         <Button

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-preview.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FormEvent, SetStateAction, useState } from "react";
+import { Dispatch, FormEvent, SetStateAction, useMemo, useState } from "react";
 import {
     Button,
     Card,
@@ -70,8 +70,7 @@ export const InductionProfilePreview = ({
         setIsLoading(false);
     };
 
-    const prepareMemberCard = () => {
-        // TODO: memoize
+    const memberCardData = useMemo(() => {
         let pendingProfile = profileInfo;
         if (selectedPhoto) {
             const img = URL.createObjectURL(selectedPhoto);
@@ -81,11 +80,11 @@ export const InductionProfilePreview = ({
             pendingProfile!,
             induction.invitee
         );
-    };
+    }, [induction.invitee, profileInfo, selectedPhoto]);
 
     return (
         <>
-            <MemberCardPreview memberData={prepareMemberCard()} />
+            <MemberCardPreview memberData={memberCardData} />
             <Card>
                 <form
                     onSubmit={submitInductionProfileTransaction}

--- a/packages/webapp/src/inductions/components/induction-journeys/inviter-witness-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/inviter-witness-journey.tsx
@@ -106,6 +106,9 @@ const RecommendReview = ({
     setIsRevisitingVideo: Dispatch<SetStateAction<boolean>>;
 }) => (
     <div className="mt-4 space-y-3">
+        <Heading size={2} className="mb-2">
+            Review profile
+        </Heading>
         <Text>
             Carefully review the prospective member profile information below.
             Make sure that all social handles and links are accurate and
@@ -214,12 +217,10 @@ const PendingEndorsementStep = ({
             <InductionExpiresIn induction={induction} />
             <EndorsementsStatus endorsements={endorsements} />
             {userEndorsementIsPending ? (
-                <>
-                    <RecommendReview
-                        setIsRevisitingVideo={setIsRevisitingVideo}
-                    />
-                    <InductionEndorsementForm induction={induction} />
-                </>
+                <InductionEndorsementForm
+                    induction={induction}
+                    setIsRevisitingVideo={setIsRevisitingVideo}
+                />
             ) : (
                 <>
                     <Text>

--- a/packages/webapp/src/inductions/components/induction-journeys/inviter-witness-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/inviter-witness-journey.tsx
@@ -122,7 +122,11 @@ const RecommendReview = ({
 );
 
 const SubmittedVideoStep = ({ induction }: { induction: Induction }) => {
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     return (
         <Container
             step={InductionStepInviter.VideoAndEndorse}
@@ -144,7 +148,11 @@ const VideoStep = ({
     isReviewingVideo,
     setSubmittedVideo,
 }: VideoStepProps) => {
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     return (
         <Container
             step={InductionStepInviter.VideoAndEndorse}
@@ -186,7 +194,11 @@ const PendingEndorsementStep = ({
     setIsReviewingVideo,
 }: PendingCompletionProps) => {
     const [ualAccount] = useUALAccount();
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     const userEndorsementIsPending =
         endorsements.find((e) => e.endorser === ualAccount?.accountName)
             ?.endorsed === 0;
@@ -228,7 +240,11 @@ const PendingDonationStep = ({
     setIsReviewingVideo,
 }: PendingCompletionProps) => {
     const { data: isCommunityActive } = useIsCommunityActive();
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     return (
         <Container
             step={

--- a/packages/webapp/src/inductions/components/induction-journeys/inviter-witness-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/inviter-witness-journey.tsx
@@ -33,19 +33,19 @@ export const InviterWitnessJourney = ({
     inductionStatus,
 }: Props) => {
     const [submittedVideo, setSubmittedVideo] = useState(false);
-    const [isReviewingVideo, setIsReviewingVideo] = useState(false);
+    const [isRevisitingVideo, setIsRevisitingVideo] = useState(false);
 
     if (submittedVideo) {
         // not possible in Genesis mode
         return <SubmittedVideoStep induction={induction} />;
     }
 
-    if (isReviewingVideo) {
+    if (isRevisitingVideo) {
         // not possible in Genesis mode
         return (
             <VideoStep
                 induction={induction}
-                isReviewingVideo={isReviewingVideo}
+                isRevisitingVideo={isRevisitingVideo}
                 setSubmittedVideo={setSubmittedVideo}
             />
         );
@@ -58,7 +58,7 @@ export const InviterWitnessJourney = ({
             return (
                 <VideoStep
                     induction={induction}
-                    isReviewingVideo={isReviewingVideo}
+                    isRevisitingVideo={isRevisitingVideo}
                     setSubmittedVideo={setSubmittedVideo}
                 />
             );
@@ -67,7 +67,7 @@ export const InviterWitnessJourney = ({
                 <PendingEndorsementStep
                     induction={induction}
                     endorsements={endorsements}
-                    setIsReviewingVideo={setIsReviewingVideo}
+                    setIsRevisitingVideo={setIsRevisitingVideo}
                 />
             );
         case InductionStatus.PendingDonation:
@@ -75,7 +75,7 @@ export const InviterWitnessJourney = ({
                 <PendingDonationStep
                     induction={induction}
                     endorsements={endorsements}
-                    setIsReviewingVideo={setIsReviewingVideo}
+                    setIsRevisitingVideo={setIsRevisitingVideo}
                 />
             );
         default:
@@ -101,9 +101,9 @@ const Container = ({ step, memberPreview, children }: ContainerProps) => (
 );
 
 const RecommendReview = ({
-    setIsReviewingVideo,
+    setIsRevisitingVideo,
 }: {
-    setIsReviewingVideo: Dispatch<SetStateAction<boolean>>;
+    setIsRevisitingVideo: Dispatch<SetStateAction<boolean>>;
 }) => (
     <div className="mt-4 space-y-3">
         <Text>
@@ -114,7 +114,7 @@ const RecommendReview = ({
         </Text>
         <Text>
             If the induction video needs to be corrected,{" "}
-            <Link onClick={() => setIsReviewingVideo(true)}>click here</Link>.
+            <Link onClick={() => setIsRevisitingVideo(true)}>click here</Link>.
             Keep in mind that modifying the induction video will reset any
             endorsements.
         </Text>
@@ -139,13 +139,13 @@ const SubmittedVideoStep = ({ induction }: { induction: Induction }) => {
 
 interface VideoStepProps {
     induction: Induction;
-    isReviewingVideo: boolean;
+    isRevisitingVideo: boolean;
     setSubmittedVideo: Dispatch<SetStateAction<boolean>>;
 }
 
 const VideoStep = ({
     induction,
-    isReviewingVideo,
+    isRevisitingVideo,
     setSubmittedVideo,
 }: VideoStepProps) => {
     const memberData = convertPendingProfileToMemberData(
@@ -160,7 +160,7 @@ const VideoStep = ({
         >
             <InductionVideoFormContainer
                 induction={induction}
-                isReviewingVideo={isReviewingVideo}
+                isRevisitingVideo={isRevisitingVideo}
                 setSubmittedVideo={setSubmittedVideo}
             />
         </Container>
@@ -185,13 +185,13 @@ const PendingProfileStep = ({ induction }: { induction: Induction }) => {
 interface PendingCompletionProps {
     induction: Induction;
     endorsements: Endorsement[];
-    setIsReviewingVideo: Dispatch<SetStateAction<boolean>>;
+    setIsRevisitingVideo: Dispatch<SetStateAction<boolean>>;
 }
 
 const PendingEndorsementStep = ({
     induction,
     endorsements,
-    setIsReviewingVideo,
+    setIsRevisitingVideo,
 }: PendingCompletionProps) => {
     const [ualAccount] = useUALAccount();
     const memberData = convertPendingProfileToMemberData(
@@ -216,7 +216,7 @@ const PendingEndorsementStep = ({
             {userEndorsementIsPending ? (
                 <>
                     <RecommendReview
-                        setIsReviewingVideo={setIsReviewingVideo}
+                        setIsRevisitingVideo={setIsRevisitingVideo}
                     />
                     <InductionEndorsementForm induction={induction} />
                 </>
@@ -226,7 +226,7 @@ const PendingEndorsementStep = ({
                         Waiting for all witnesses to endorse. In the meantime:
                     </Text>
                     <RecommendReview
-                        setIsReviewingVideo={setIsReviewingVideo}
+                        setIsRevisitingVideo={setIsRevisitingVideo}
                     />
                 </>
             )}
@@ -237,7 +237,7 @@ const PendingEndorsementStep = ({
 const PendingDonationStep = ({
     induction,
     endorsements,
-    setIsReviewingVideo,
+    setIsRevisitingVideo,
 }: PendingCompletionProps) => {
     const { data: isCommunityActive } = useIsCommunityActive();
     const memberData = convertPendingProfileToMemberData(
@@ -268,7 +268,7 @@ const PendingDonationStep = ({
                         Eden NFTs will be minted and distributed.
                     </Text>
                     <RecommendReview
-                        setIsReviewingVideo={setIsReviewingVideo}
+                        setIsRevisitingVideo={setIsRevisitingVideo}
                     />
                 </>
             ) : (

--- a/packages/webapp/src/inductions/components/induction-journeys/inviter-witnesses/endorsement-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/inviter-witnesses/endorsement-form.tsx
@@ -1,27 +1,36 @@
-import { useState } from "react";
+import { Dispatch, FormEvent, SetStateAction, useState } from "react";
 import { useQueryClient } from "react-query";
+import { RiVideoUploadFill } from "react-icons/ri";
+import { FaPlayCircle } from "react-icons/fa";
 
 import {
-    onError,
     Button,
     Form,
-    useUALAccount,
+    Heading,
+    ipfsUrl,
+    onError,
     queryInductionWithEndorsements,
+    Text,
+    useUALAccount,
 } from "_app";
 import { submitEndorsementTransaction } from "inductions";
 import { Induction } from "inductions/interfaces";
 
 interface Props {
     induction: Induction;
+    setIsRevisitingVideo: Dispatch<SetStateAction<boolean>>;
 }
 
-export const InductionEndorsementForm = ({ induction }: Props) => {
+export const InductionEndorsementForm = ({
+    induction,
+    setIsRevisitingVideo,
+}: Props) => {
     const [ualAccount] = useUALAccount();
     const queryClient = useQueryClient();
-    const [isReviewed, setReviewed] = useState(false);
     const [isLoading, setLoading] = useState(false);
 
-    const submitEndorsement = async () => {
+    const submitEndorsement = async (e: FormEvent) => {
+        e.preventDefault();
         try {
             const authorizerAccount = ualAccount.accountName;
             const transaction = await submitEndorsementTransaction(
@@ -51,24 +60,82 @@ export const InductionEndorsementForm = ({ induction }: Props) => {
     };
 
     return (
-        <div className="mt-4">
-            <div className="flex items-end xl:items-center flex-col xl:flex-row p-3 border rounded-md">
-                <Form.Checkbox
-                    id="reviewed"
-                    label="I have carefully reviewed the prospective member's profile information below and affirm my endorsement"
-                    value={Number(isReviewed)}
-                    onChange={() => setReviewed(!isReviewed)}
-                />
-                <div className="pt-1 justify-end">
-                    <Button
-                        disabled={isLoading || !isReviewed}
-                        onClick={submitEndorsement}
-                        isLoading={isLoading}
-                    >
-                        {isLoading ? "Submitting..." : "Submit"}
+        <form onSubmit={submitEndorsement} className="mt-4 space-y-4">
+            <section id="profile-review" className="space-y-2">
+                <div className="mt-4 space-y-3">
+                    <Heading size={2} className="mb-2">
+                        Review profile
+                    </Heading>
+                    <Text>
+                        Carefully review the prospective member's profile below
+                        as per the following check boxes. If anything needs to
+                        be corrected, ask the invitee to sign in and make the
+                        required corrections.
+                    </Text>
+                </div>
+                <div className="p-3 border rounded">
+                    <Form.Checkbox
+                        id="photo"
+                        label="The person in the profile photo below is the same person who appeared in the induction ceremony video call. Their face is clearly visible in the image (no mask, sunglasses, etc.)"
+                        disabled={isLoading}
+                        required
+                    />
+                </div>
+                <div className="p-3 border rounded">
+                    <Form.Checkbox
+                        id="links"
+                        label="I have visited each social link below and affirm that all links are working properly and appear to belong to the invitee."
+                        disabled={isLoading}
+                        required
+                    />
+                </div>
+            </section>
+            <section id="video-review" className="space-y-2">
+                <Heading size={2} className="mb-2">
+                    Review video
+                </Heading>
+                <div className="flex flex-col items-center p-3 border rounded space-y-2">
+                    <Form.Checkbox
+                        id="video"
+                        label="The correct induction ceremony video is attached and participants are visible in the video."
+                        disabled={isLoading}
+                        required
+                    />
+                    <div className="flex flex-col sm:flex-row lg:flex-col xl:flex-row">
+                        <Button
+                            type="link"
+                            href={ipfsUrl(induction.video)}
+                            target="_blank"
+                        >
+                            <FaPlayCircle className="mr-2" />
+                            Review video
+                        </Button>
+                        <Button
+                            type="link"
+                            onClick={() => setIsRevisitingVideo(true)}
+                        >
+                            <RiVideoUploadFill className="mr-2" />
+                            Replace video
+                        </Button>
+                    </div>
+                </div>
+            </section>
+            <section id="make-endorsement" className="space-y-2">
+                <Heading size={2} className="">
+                    Endorse
+                </Heading>
+                <div className="flex flex-col space-y-2 items-center md:flex-row md:space-y-0 lg:flex-col lg:space-y-2 xl:flex-row xl:space-y-0 p-3 border rounded space-x-2">
+                    <Form.Checkbox
+                        id="reviewed"
+                        label="I hereby endorse this individual for membership in the Eden community."
+                        disabled={isLoading}
+                        required
+                    />
+                    <Button disabled={isLoading} isLoading={isLoading} isSubmit>
+                        {isLoading ? "Submitting..." : "Endorse"}
                     </Button>
                 </div>
-            </div>
-        </div>
+            </section>
+        </form>
     );
 };

--- a/packages/webapp/src/inductions/components/induction-journeys/inviter-witnesses/video-form-container.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/inviter-witnesses/video-form-container.tsx
@@ -18,13 +18,13 @@ import { InductionVideoForm, VideoSubmissionPhase } from "./video-form";
 
 interface Props {
     induction: Induction;
-    isReviewingVideo: boolean;
+    isRevisitingVideo: boolean;
     setSubmittedVideo: Dispatch<SetStateAction<boolean>>;
 }
 
 export const InductionVideoFormContainer = ({
     induction,
-    isReviewingVideo,
+    isRevisitingVideo,
     setSubmittedVideo,
 }: Props) => {
     const [ualAccount] = useUALAccount();
@@ -68,7 +68,7 @@ export const InductionVideoFormContainer = ({
     return (
         <>
             <Heading size={1} className="mb-2">
-                {isReviewingVideo
+                {isRevisitingVideo
                     ? "Review induction video"
                     : "Induction ceremony"}
             </Heading>

--- a/packages/webapp/src/inductions/components/induction-journeys/third-party-journey.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/third-party-journey.tsx
@@ -83,7 +83,11 @@ const PendingProfileStep = ({ induction }: { induction: Induction }) => {
 };
 
 const PendingVideoStep = ({ induction }: { induction: Induction }) => {
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     return (
         <Container
             step={InductionStepInvitee.PendingVideoAndEndorsements}
@@ -103,7 +107,11 @@ const PendingEndorsementStep = ({
     induction,
     endorsements,
 }: PendingCompletionProps) => {
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     return (
         <Container
             step={InductionStepInvitee.PendingVideoAndEndorsements}
@@ -124,7 +132,11 @@ const PendingDonationStep = ({
     endorsements,
 }: PendingCompletionProps) => {
     const { data: isCommunityActive } = useIsCommunityActive();
-    const memberData = convertPendingProfileToMemberData(induction);
+    const memberData = convertPendingProfileToMemberData(
+        induction.new_member_profile,
+        induction.invitee,
+        induction.video
+    );
     return (
         <Container
             step={

--- a/packages/webapp/src/inductions/utils.ts
+++ b/packages/webapp/src/inductions/utils.ts
@@ -7,22 +7,25 @@ import {
     Induction,
     InductionRole,
     InductionStatus,
+    NewMemberProfile,
 } from "./interfaces";
 
 const INDUCTION_EXPIRATION_DAYS = 7;
 
 export const convertPendingProfileToMemberData = (
-    induction: Induction
+    profile: NewMemberProfile,
+    inviteeChainAccountName: string,
+    inductionVideo?: string
 ): MemberData => {
     return {
         templateId: 0,
-        name: induction.new_member_profile.name,
-        image: induction.new_member_profile.img,
-        account: induction.invitee,
-        bio: induction.new_member_profile.bio,
-        socialHandles: JSON.parse(induction.new_member_profile.social || "{}"),
-        inductionVideo: induction.video || "",
-        attributions: induction.new_member_profile.attributions || "",
+        name: profile.name,
+        image: profile.img,
+        account: inviteeChainAccountName,
+        bio: profile.bio,
+        socialHandles: JSON.parse(profile.social || "{}"),
+        inductionVideo: inductionVideo || "",
+        attributions: profile.attributions || "",
         createdAt: 0,
     };
 };

--- a/packages/webapp/src/members/components/member-holo-card.tsx
+++ b/packages/webapp/src/members/components/member-holo-card.tsx
@@ -30,7 +30,11 @@ export const MemberHoloCard = ({ member, inducted = true }: Props) => {
                 style={{ padding: width * 0.047 }}
             >
                 <img
-                    src={ipfsUrl(member.image)}
+                    src={
+                        member.image.startsWith("blob:")
+                            ? member.image
+                            : ipfsUrl(member.image)
+                    }
                     className="rounded-full object-cover bg-white"
                     title={memberImageTitle}
                     style={{


### PR DESCRIPTION
For the invitee, this separates the profile from step from the profile review step. After the user fills in the profile form, they're asked to preview their profile. This takes them to a preview with 5 checkboxes asking them to verify the accuracy and compliance of different aspects of the profile. From that screen, they can either go back and make edits, or submit the profile (which kicks off the profile transaction.)

![telegram-cloud-photo-size-1-5114180047006181674-y](https://user-images.githubusercontent.com/7911424/124192121-c596b200-da92-11eb-9a7f-5eae3dc8abf3.jpg)

![telegram-cloud-photo-size-1-5114180047006181675-y](https://user-images.githubusercontent.com/7911424/124192130-c9c2cf80-da92-11eb-8357-396c1d699640.jpg)

![telegram-cloud-photo-size-1-5116197904246221870-y](https://user-images.githubusercontent.com/7911424/124323255-fa683f00-db4e-11eb-8c12-e5504da7771f.jpg)

### What's left?
- [x] Get feedback from community members on wording (in progress)
- [x] Add checkboxes for inviter and witnesses too asking them to validate similar aspects of the profile and ensure the profile information corresponds to the person that was on video with them.
- [x] Retest inductions end-to-end