### PR TITLE
EdenOS Release v0.1.10 Patch

### DIFF
--- a/packages/webapp/src/members/components/member-social-links.tsx
+++ b/packages/webapp/src/members/components/member-social-links.tsx
@@ -30,7 +30,7 @@ export const MemberSocialLinks = ({ member }: Props) => {
                 <SocialButton
                     handle={member.socialHandles.eosCommunity}
                     icon={IoChatbubblesOutline}
-                    href={`https://eoscommunity.org/u/${member.socialHandles.eosCommunity}`}
+                    href={`https://forums.eoscommunity.org/u/${member.socialHandles.eosCommunity}`}
                 />
             )}
             {member.socialHandles.blog && (


### PR DESCRIPTION
Adds forums subdomain to currently-broken eoscommunity social links. Domain no longer forwards those properly. 