### PR TITLE
UI: MemberChip Abstraction and Permutations for Elections

### DIFF
--- a/packages/webapp/src/_app/ui/generic-member-chip.tsx
+++ b/packages/webapp/src/_app/ui/generic-member-chip.tsx
@@ -1,0 +1,53 @@
+import { ipfsUrl } from "_app";
+import { MemberData } from "members/interfaces";
+
+interface Props {
+    member: MemberData;
+    actionComponent?: React.ReactNode;
+    contentComponent: React.ReactNode;
+    onClickChip?: (e: React.MouseEvent) => void;
+    onClickProfileImage?: (e: React.MouseEvent) => void;
+}
+
+export const GenericMemberChip = ({
+    member,
+    onClickChip,
+    onClickProfileImage,
+    actionComponent,
+    contentComponent,
+}: Props) => (
+    <div
+        className="relative flex items-center justify-between p-2.5 bg-white hover:bg-gray-100 active:bg-gray-200 transition select-none cursor-pointer"
+        style={{ boxShadow: "0 0 0 1px #e5e5e5" }}
+        onClick={onClickChip}
+    >
+        <div className="flex space-x-2.5">
+            <MemberImage
+                member={member}
+                onClick={onClickProfileImage || onClickChip}
+            />
+            {contentComponent}
+        </div>
+        {actionComponent}
+    </div>
+);
+
+interface MemberImageProps {
+    member: MemberData;
+    onClick?: (e: React.MouseEvent) => void;
+}
+
+const MemberImage = ({ member, onClick }: MemberImageProps) => {
+    const imageClass = "rounded-full h-14 w-14 object-cover shadow";
+    if (member.account && member.image) {
+        return (
+            <div className="relative group" onClick={onClick}>
+                <img src={ipfsUrl(member.image)} className={imageClass} />
+                <div className="absolute inset-0 bg-black opacity-0 group-hover:opacity-20 transition rounded-full" />
+            </div>
+        );
+    }
+    return <img src={"/images/unknown-member.png"} className={imageClass} />;
+};
+
+export default GenericMemberChip;

--- a/packages/webapp/src/_app/ui/index.ts
+++ b/packages/webapp/src/_app/ui/index.ts
@@ -2,6 +2,7 @@ export * from "./button";
 export * from "./container";
 export * from "./heading";
 export * from "./form";
+export * from "./generic-member-chip";
 export * from "./help-link";
 export * from "./link";
 export * from "./opens-in-new-tab-icon";

--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { FaMedal, FaRegSquare, FaSquare } from "react-icons/fa";
+import { FaCheckSquare, FaRegSquare, FaRegStar } from "react-icons/fa";
 
 import { ROUTES } from "_app/config";
 import { GenericMemberChip } from "_app/ui";
@@ -31,14 +31,11 @@ export const VotingMemberChip = ({
             }
             actionComponent={
                 isSelected ? (
-                    <FaSquare
-                        size={31}
-                        className="text-gray-600 hover:text-gray-700"
-                    />
+                    <FaCheckSquare size={31} className="mr-2 text-blue-500" />
                 ) : (
                     <FaRegSquare
                         size={31}
-                        className="text-gray-300 hover:text-gray-400"
+                        className="mr-2 text-gray-300 hover:text-gray-400"
                     />
                 )
             }
@@ -59,11 +56,17 @@ export const WinningMemberChip = ({ member }: { member: MemberData }) => {
         <GenericMemberChip
             member={member}
             contentComponent={<MemberDetails member={member} />}
-            actionComponent={<FaMedal size={31} className="text-gray-700" />}
+            actionComponent={<WinnerBadge />}
             onClickChip={goToMemberPage}
         />
     );
 };
+
+const WinnerBadge = () => (
+    <div className="flex justify-center items-center rounded-full mr-2 p-1 border border-yellow-800 bg-yellow-500">
+        <FaRegStar size={14} className="text-white" />
+    </div>
+);
 
 interface MemberDetailsProps {
     member: MemberData;

--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -1,0 +1,81 @@
+import { useRouter } from "next/router";
+import { FaMedal, FaRegSquare, FaSquare } from "react-icons/fa";
+
+import { ROUTES } from "_app/config";
+import { GenericMemberChip } from "_app/ui";
+import { MemberData } from "members/interfaces";
+
+interface VotingProps {
+    member: MemberData;
+    onSelect: () => void;
+    isSelected: boolean;
+}
+
+export const VotingMemberChip = ({
+    member,
+    onSelect,
+    isSelected,
+}: VotingProps) => {
+    const router = useRouter();
+
+    const goToMemberPage = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
+    };
+
+    return (
+        <GenericMemberChip
+            member={member}
+            contentComponent={
+                <MemberDetails member={member} onClick={goToMemberPage} />
+            }
+            actionComponent={
+                isSelected ? (
+                    <FaSquare
+                        size={31}
+                        className="text-gray-600 hover:text-gray-700"
+                    />
+                ) : (
+                    <FaRegSquare
+                        size={31}
+                        className="text-gray-300 hover:text-gray-400"
+                    />
+                )
+            }
+            onClickChip={onSelect}
+        />
+    );
+};
+
+export const WinningMemberChip = ({ member }: { member: MemberData }) => {
+    const router = useRouter();
+
+    const goToMemberPage = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
+    };
+
+    return (
+        <GenericMemberChip
+            member={member}
+            contentComponent={<MemberDetails member={member} />}
+            actionComponent={<FaMedal size={31} className="text-gray-700" />}
+            onClickChip={goToMemberPage}
+        />
+    );
+};
+
+interface MemberDetailsProps {
+    member: MemberData;
+    onClick?: (e: React.MouseEvent) => void;
+}
+
+export const MemberDetails = ({ member, onClick }: MemberDetailsProps) => (
+    <div
+        onClick={onClick}
+        className="flex-1 flex flex-col justify-center group"
+    >
+        <p className="text-xs text-gray-500 font-light">@{member.account}</p>
+        <p className="group-hover:underline">{member.name}</p>
+    </div>
+);

--- a/packages/webapp/src/elections/components/index.ts
+++ b/packages/webapp/src/elections/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./election-member-chips";

--- a/packages/webapp/src/elections/index.ts
+++ b/packages/webapp/src/elections/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/packages/webapp/src/members/components/index.ts
+++ b/packages/webapp/src/members/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./member-card";
+export * from "./member-chip";
 export * from "./member-collections";
 export * from "./member-holo-card";
 export * from "./member-social-links";

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -1,0 +1,193 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import dayjs from "dayjs";
+import { FaGavel } from "react-icons/fa";
+
+import { atomicAssets, blockExplorerAccountBaseUrl } from "config";
+import { assetToString, ipfsUrl } from "_app";
+import { ROUTES } from "_app/config";
+
+import { MemberData } from "../interfaces";
+
+const openInNewTab = (url: string) => {
+    const newWindow = window.open(url, "_blank", "noopener,noreferrer");
+    if (newWindow) newWindow.opener = null;
+};
+
+interface Props {
+    children?: React.ReactNode;
+    member: MemberData;
+    onClickChip?: (e: React.MouseEvent) => void;
+    onClickProfileImage?: (e: React.MouseEvent) => void;
+}
+
+// TODO: Extract to new component.
+export const MemberChip = ({
+    member,
+    onClickChip,
+    onClickProfileImage,
+    children,
+}: Props) => {
+    const router = useRouter();
+
+    const onClickMember = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
+    };
+
+    const memberChip = (
+        <div
+            className="relative flex items-center justify-between p-2.5 bg-white hover:bg-gray-100 active:bg-gray-200 transition select-none cursor-pointer"
+            style={{ boxShadow: "0 0 0 1px #e5e5e5" }}
+            onClick={onClickChip}
+        >
+            <div className="flex space-x-2.5">
+                <MemberImage
+                    member={member}
+                    onClick={onClickProfileImage ?? onClickMember}
+                />
+                <div
+                    onClick={onClickMember}
+                    className="flex-1 flex flex-col justify-center group"
+                >
+                    <p className="text-xs text-gray-500 font-light">
+                        {member.createdAt === 0
+                            ? "not an eden member"
+                            : dayjs(member.createdAt).format("YYYY.MM.DD")}
+                    </p>
+                    <p className="group-hover:underline">{member.name}</p>
+                    {member.account && (
+                        <p className="text-xs text-gray-500 font-light">
+                            @{member.account}
+                        </p>
+                    )}
+                </div>
+            </div>
+            {/* TODO: Pass in NFTBadges as children where invoked? */}
+            <NFTBadges member={member} />
+            {children}
+        </div>
+    );
+
+    if (onClickChip) {
+        return memberChip;
+    }
+
+    if (member.account) {
+        // TODO: Change to onClick? Should anchor tag have clickable children?
+        return (
+            <Link href={`${ROUTES.MEMBERS.href}/${member.account}`}>
+                <a>{memberChip}</a>
+            </Link>
+        );
+    }
+    return (
+        <a
+            href={`${blockExplorerAccountBaseUrl}/${member.name}`}
+            target="_blank"
+            rel="noopener noreferrer"
+        >
+            {memberChip}
+        </a>
+    );
+};
+
+interface MemberImageProps {
+    member: MemberData;
+    onClick?: (e: React.MouseEvent) => void;
+}
+
+const MemberImage = ({ member, onClick }: MemberImageProps) => {
+    const imageClass = "rounded-full h-14 w-14 object-cover shadow";
+    if (member.account && member.image) {
+        return (
+            <div className="relative group" onClick={onClick}>
+                <img src={ipfsUrl(member.image)} className={imageClass} />
+                <div className="absolute inset-0 bg-black opacity-0 group-hover:opacity-20 transition rounded-full" />
+            </div>
+        );
+    }
+    return <img src={"/images/unknown-member.png"} className={imageClass} />;
+};
+
+const NFTBadges = ({ member }: { member: MemberData }) => (
+    <div className="absolute right-0 bottom-0 p-2.5 space-y-0.5">
+        <AuctionBadge member={member} />
+        <SaleBadge member={member} />
+        {!member.auctionData && !member.saleId && (
+            <AssetBadge member={member} />
+        )}
+    </div>
+);
+
+const AssetBadge = ({ member }: { member: MemberData }) => {
+    if (member.assetData) {
+        return (
+            <div
+                className="group flex justify-end items-center space-x-1"
+                onClick={(e) => {
+                    e.preventDefault();
+                    openInNewTab(
+                        `${atomicAssets.hubUrl}/explorer/asset/${member?.assetData?.assetId}`
+                    );
+                }}
+            >
+                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
+                    NFT #{member.assetData.templateMint}
+                </p>
+            </div>
+        );
+    }
+    return <></>;
+};
+
+const AuctionBadge = ({ member }: { member: MemberData }) => {
+    if (member.auctionData) {
+        return (
+            <div
+                className="group flex justify-end items-center space-x-1"
+                onClick={(e) => {
+                    e.preventDefault();
+                    openInNewTab(
+                        `${atomicAssets.hubUrl}/market/auction/${member?.auctionData?.auctionId}`
+                    );
+                }}
+            >
+                <FaGavel
+                    size={14}
+                    className="text-gray-600 group-hover:text-gray-800"
+                />
+                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
+                    {assetToString(member.auctionData.price, 2)} (#
+                    {member.assetData?.templateMint})
+                </p>
+            </div>
+        );
+    }
+
+    return <></>;
+};
+
+const SaleBadge = ({ member }: { member: MemberData }) => {
+    if (member.saleId) {
+        return (
+            <div
+                className="group flex justify-end items-center space-x-1"
+                onClick={(e) => {
+                    e.preventDefault();
+                    openInNewTab(
+                        `${atomicAssets.hubUrl}/market/sale/${member.saleId}`
+                    );
+                }}
+            >
+                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
+                    ON SALE (#
+                    {member.assetData?.templateMint})
+                </p>
+            </div>
+        );
+    }
+    return <></>;
+};
+
+export default MemberChip;

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { useRouter } from "next/router";
 import dayjs from "dayjs";
 import { FaGavel } from "react-icons/fa";
@@ -21,7 +20,6 @@ interface Props {
     onClickProfileImage?: (e: React.MouseEvent) => void;
 }
 
-// TODO: Extract to new component.
 export const MemberChip = ({
     member,
     onClickChip,
@@ -31,6 +29,7 @@ export const MemberChip = ({
     const router = useRouter();
 
     const onClickMember = (e: React.MouseEvent) => {
+        if (!member.account) return undefined;
         e.stopPropagation();
         router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
     };
@@ -39,7 +38,7 @@ export const MemberChip = ({
         <div
             className="relative flex items-center justify-between p-2.5 bg-white hover:bg-gray-100 active:bg-gray-200 transition select-none cursor-pointer"
             style={{ boxShadow: "0 0 0 1px #e5e5e5" }}
-            onClick={onClickChip}
+            onClick={onClickChip ?? onClickMember}
         >
             <div className="flex space-x-2.5">
                 <MemberImage
@@ -47,7 +46,7 @@ export const MemberChip = ({
                     onClick={onClickProfileImage ?? onClickMember}
                 />
                 <div
-                    onClick={onClickMember}
+                    onClick={member.account ? onClickMember : undefined}
                     className="flex-1 flex flex-col justify-center group"
                 >
                     <p className="text-xs text-gray-500 font-light">
@@ -63,24 +62,14 @@ export const MemberChip = ({
                     )}
                 </div>
             </div>
-            {/* TODO: Pass in NFTBadges as children where invoked? */}
-            <NFTBadges member={member} />
             {children}
         </div>
     );
 
-    if (onClickChip) {
+    if (member.account) {
         return memberChip;
     }
 
-    if (member.account) {
-        // TODO: Change to onClick? Should anchor tag have clickable children?
-        return (
-            <Link href={`${ROUTES.MEMBERS.href}/${member.account}`}>
-                <a>{memberChip}</a>
-            </Link>
-        );
-    }
     return (
         <a
             href={`${blockExplorerAccountBaseUrl}/${member.name}`}
@@ -91,6 +80,16 @@ export const MemberChip = ({
         </a>
     );
 };
+
+export const MemberChipNFTBadges = ({ member }: { member: MemberData }) => (
+    <div className="absolute right-0 bottom-0 p-2.5 space-y-0.5">
+        <AuctionBadge member={member} />
+        <SaleBadge member={member} />
+        {!member.auctionData && !member.saleId && (
+            <AssetBadge member={member} />
+        )}
+    </div>
+);
 
 interface MemberImageProps {
     member: MemberData;
@@ -109,16 +108,6 @@ const MemberImage = ({ member, onClick }: MemberImageProps) => {
     }
     return <img src={"/images/unknown-member.png"} className={imageClass} />;
 };
-
-const NFTBadges = ({ member }: { member: MemberData }) => (
-    <div className="absolute right-0 bottom-0 p-2.5 space-y-0.5">
-        <AuctionBadge member={member} />
-        <SaleBadge member={member} />
-        {!member.auctionData && !member.saleId && (
-            <AssetBadge member={member} />
-        )}
-    </div>
-);
 
 const AssetBadge = ({ member }: { member: MemberData }) => {
     if (member.assetData) {

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -1,9 +1,11 @@
+import React from "react";
 import { useRouter } from "next/router";
 import dayjs from "dayjs";
 import { FaGavel } from "react-icons/fa";
 
 import { atomicAssets, blockExplorerAccountBaseUrl } from "config";
 import { assetToString, ipfsUrl } from "_app";
+import { GenericMemberChip } from "_app/ui";
 import { ROUTES } from "_app/config";
 
 import { MemberData } from "../interfaces";
@@ -13,78 +15,36 @@ const openInNewTab = (url: string) => {
     if (newWindow) newWindow.opener = null;
 };
 
-interface Props {
-    children?: React.ReactNode;
-    member: MemberData;
-    onClickChip?: (e: React.MouseEvent) => void;
-    onClickProfileImage?: (e: React.MouseEvent) => void;
-}
-
-export const MemberChip = ({
-    member,
-    onClickChip,
-    onClickProfileImage,
-    children,
-}: Props) => {
+export const MemberChip = ({ member }: { member: MemberData }) => {
     const router = useRouter();
 
-    const onClickMember = (e: React.MouseEvent) => {
-        if (!member.account) return undefined;
-        e.stopPropagation();
-        router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
+    const onClick = (e: React.MouseEvent) => {
+        if (member.account) {
+            e.stopPropagation();
+            router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
+        } else {
+            openInNewTab(`${blockExplorerAccountBaseUrl}/${member.name}`);
+        }
     };
 
-    const memberChip = (
-        <div
-            className="relative flex items-center justify-between p-2.5 bg-white hover:bg-gray-100 active:bg-gray-200 transition select-none cursor-pointer"
-            style={{ boxShadow: "0 0 0 1px #e5e5e5" }}
-            onClick={onClickChip ?? onClickMember}
-        >
-            <div className="flex space-x-2.5">
-                <MemberImage
-                    member={member}
-                    onClick={onClickProfileImage ?? onClickMember}
-                />
-                <MemberDetails member={member} onClick={onClickMember} />
-            </div>
-            {children}
-        </div>
-    );
-
-    if (member.account) {
-        return memberChip;
-    }
-
     return (
-        <a
-            href={`${blockExplorerAccountBaseUrl}/${member.name}`}
-            target="_blank"
-            rel="noopener noreferrer"
-        >
-            {memberChip}
-        </a>
+        <GenericMemberChip
+            member={member}
+            onClickChip={onClick}
+            contentComponent={
+                <MemberDetails member={member} onClick={onClick} />
+            }
+            actionComponent={<MemberChipNFTBadges member={member} />}
+        />
     );
 };
 
-interface MemberDetailProps {
+interface MemberDetailsProps {
     member: MemberData;
     onClick?: (e: React.MouseEvent) => void;
 }
 
-const MemberImage = ({ member, onClick }: MemberDetailProps) => {
-    const imageClass = "rounded-full h-14 w-14 object-cover shadow";
-    if (member.account && member.image) {
-        return (
-            <div className="relative group" onClick={onClick}>
-                <img src={ipfsUrl(member.image)} className={imageClass} />
-                <div className="absolute inset-0 bg-black opacity-0 group-hover:opacity-20 transition rounded-full" />
-            </div>
-        );
-    }
-    return <img src={"/images/unknown-member.png"} className={imageClass} />;
-};
-
-const MemberDetails = ({ member, onClick }: MemberDetailProps) => (
+export const MemberDetails = ({ member, onClick }: MemberDetailsProps) => (
     <div
         onClick={onClick}
         className="flex-1 flex flex-col justify-center group"
@@ -119,7 +79,7 @@ const AssetBadge = ({ member }: { member: MemberData }) => {
             <div
                 className="group flex justify-end items-center space-x-1"
                 onClick={(e) => {
-                    e.preventDefault();
+                    e.stopPropagation();
                     openInNewTab(
                         `${atomicAssets.hubUrl}/explorer/asset/${member?.assetData?.assetId}`
                     );
@@ -140,7 +100,7 @@ const AuctionBadge = ({ member }: { member: MemberData }) => {
             <div
                 className="group flex justify-end items-center space-x-1"
                 onClick={(e) => {
-                    e.preventDefault();
+                    e.stopPropagation();
                     openInNewTab(
                         `${atomicAssets.hubUrl}/market/auction/${member?.auctionData?.auctionId}`
                     );
@@ -167,7 +127,7 @@ const SaleBadge = ({ member }: { member: MemberData }) => {
             <div
                 className="group flex justify-end items-center space-x-1"
                 onClick={(e) => {
-                    e.preventDefault();
+                    e.stopPropagation();
                     openInNewTab(
                         `${atomicAssets.hubUrl}/market/sale/${member.saleId}`
                     );

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -45,22 +45,7 @@ export const MemberChip = ({
                     member={member}
                     onClick={onClickProfileImage ?? onClickMember}
                 />
-                <div
-                    onClick={member.account ? onClickMember : undefined}
-                    className="flex-1 flex flex-col justify-center group"
-                >
-                    <p className="text-xs text-gray-500 font-light">
-                        {member.createdAt === 0
-                            ? "not an eden member"
-                            : dayjs(member.createdAt).format("YYYY.MM.DD")}
-                    </p>
-                    <p className="group-hover:underline">{member.name}</p>
-                    {member.account && (
-                        <p className="text-xs text-gray-500 font-light">
-                            @{member.account}
-                        </p>
-                    )}
-                </div>
+                <MemberDetails member={member} onClick={onClickMember} />
             </div>
             {children}
         </div>
@@ -81,22 +66,12 @@ export const MemberChip = ({
     );
 };
 
-export const MemberChipNFTBadges = ({ member }: { member: MemberData }) => (
-    <div className="absolute right-0 bottom-0 p-2.5 space-y-0.5">
-        <AuctionBadge member={member} />
-        <SaleBadge member={member} />
-        {!member.auctionData && !member.saleId && (
-            <AssetBadge member={member} />
-        )}
-    </div>
-);
-
-interface MemberImageProps {
+interface MemberDetailProps {
     member: MemberData;
     onClick?: (e: React.MouseEvent) => void;
 }
 
-const MemberImage = ({ member, onClick }: MemberImageProps) => {
+const MemberImage = ({ member, onClick }: MemberDetailProps) => {
     const imageClass = "rounded-full h-14 w-14 object-cover shadow";
     if (member.account && member.image) {
         return (
@@ -108,6 +83,35 @@ const MemberImage = ({ member, onClick }: MemberImageProps) => {
     }
     return <img src={"/images/unknown-member.png"} className={imageClass} />;
 };
+
+const MemberDetails = ({ member, onClick }: MemberDetailProps) => (
+    <div
+        onClick={onClick}
+        className="flex-1 flex flex-col justify-center group"
+    >
+        <p className="text-xs text-gray-500 font-light">
+            {member.createdAt === 0
+                ? "not an eden member"
+                : dayjs(member.createdAt).format("YYYY.MM.DD")}
+        </p>
+        <p className="group-hover:underline">{member.name}</p>
+        {member.account && (
+            <p className="text-xs text-gray-500 font-light">
+                @{member.account}
+            </p>
+        )}
+    </div>
+);
+
+export const MemberChipNFTBadges = ({ member }: { member: MemberData }) => (
+    <div className="absolute right-0 bottom-0 p-2.5 space-y-0.5">
+        <AuctionBadge member={member} />
+        <SaleBadge member={member} />
+        {!member.auctionData && !member.saleId && (
+            <AssetBadge member={member} />
+        )}
+    </div>
+);
 
 const AssetBadge = ({ member }: { member: MemberData }) => {
     if (member.assetData) {

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import { FaGavel } from "react-icons/fa";
 
 import { atomicAssets, blockExplorerAccountBaseUrl } from "config";
-import { assetToString, ipfsUrl } from "_app";
+import { assetToString } from "_app";
 import { GenericMemberChip } from "_app/ui";
 import { ROUTES } from "_app/config";
 
@@ -74,73 +74,66 @@ export const MemberChipNFTBadges = ({ member }: { member: MemberData }) => (
 );
 
 const AssetBadge = ({ member }: { member: MemberData }) => {
-    if (member.assetData) {
-        return (
-            <div
-                className="group flex justify-end items-center space-x-1"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    openInNewTab(
-                        `${atomicAssets.hubUrl}/explorer/asset/${member?.assetData?.assetId}`
-                    );
-                }}
-            >
-                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
-                    NFT #{member.assetData.templateMint}
-                </p>
-            </div>
-        );
-    }
-    return <></>;
+    if (!member.assetData) return <></>;
+    return (
+        <div
+            className="group flex justify-end items-center space-x-1"
+            onClick={(e) => {
+                e.stopPropagation();
+                openInNewTab(
+                    `${atomicAssets.hubUrl}/explorer/asset/${member?.assetData?.assetId}`
+                );
+            }}
+        >
+            <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
+                NFT #{member.assetData.templateMint}
+            </p>
+        </div>
+    );
 };
 
 const AuctionBadge = ({ member }: { member: MemberData }) => {
-    if (member.auctionData) {
-        return (
-            <div
-                className="group flex justify-end items-center space-x-1"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    openInNewTab(
-                        `${atomicAssets.hubUrl}/market/auction/${member?.auctionData?.auctionId}`
-                    );
-                }}
-            >
-                <FaGavel
-                    size={14}
-                    className="text-gray-600 group-hover:text-gray-800"
-                />
-                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
-                    {assetToString(member.auctionData.price, 2)} (#
-                    {member.assetData?.templateMint})
-                </p>
-            </div>
-        );
-    }
-
-    return <></>;
+    if (!member.auctionData) return <></>;
+    return (
+        <div
+            className="group flex justify-end items-center space-x-1"
+            onClick={(e) => {
+                e.stopPropagation();
+                openInNewTab(
+                    `${atomicAssets.hubUrl}/market/auction/${member?.auctionData?.auctionId}`
+                );
+            }}
+        >
+            <FaGavel
+                size={14}
+                className="text-gray-600 group-hover:text-gray-800"
+            />
+            <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
+                {assetToString(member.auctionData.price, 2)} (#
+                {member.assetData?.templateMint})
+            </p>
+        </div>
+    );
 };
 
 const SaleBadge = ({ member }: { member: MemberData }) => {
-    if (member.saleId) {
-        return (
-            <div
-                className="group flex justify-end items-center space-x-1"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    openInNewTab(
-                        `${atomicAssets.hubUrl}/market/sale/${member.saleId}`
-                    );
-                }}
-            >
-                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
-                    ON SALE (#
-                    {member.assetData?.templateMint})
-                </p>
-            </div>
-        );
-    }
-    return <></>;
+    if (!member.saleId) return <></>;
+    return (
+        <div
+            className="group flex justify-end items-center space-x-1"
+            onClick={(e) => {
+                e.stopPropagation();
+                openInNewTab(
+                    `${atomicAssets.hubUrl}/market/sale/${member.saleId}`
+                );
+            }}
+        >
+            <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
+                ON SALE (#
+                {member.assetData?.templateMint})
+            </p>
+        </div>
+    );
 };
 
 export default MemberChip;

--- a/packages/webapp/src/members/components/member-collections.tsx
+++ b/packages/webapp/src/members/components/member-collections.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { Button, Container, Heading, LoadingCard } from "_app";
-import { MemberChip, MemberChipNFTBadges, MembersGrid } from "members";
+import { MemberChip, MembersGrid } from "members";
 
 import { getCollection, getCollectedBy } from "../api";
 import { MemberData } from "../interfaces";
@@ -76,9 +76,7 @@ export const MemberCollections = ({ member }: Props) => {
             ) : (
                 <MembersGrid members={members || []}>
                     {(member) => (
-                        <MemberChip key={member.account} member={member}>
-                            <MemberChipNFTBadges member={member} />
-                        </MemberChip>
+                        <MemberChip key={member.account} member={member} />
                     )}
                 </MembersGrid>
             )}

--- a/packages/webapp/src/members/components/member-collections.tsx
+++ b/packages/webapp/src/members/components/member-collections.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 
 import { Button, Container, Heading, LoadingCard } from "_app";
-import { MemberChip, MembersGrid } from "members";
+import { MemberChip, MemberChipNFTBadges, MembersGrid } from "members";
 
 import { getCollection, getCollectedBy } from "../api";
 import { MemberData } from "../interfaces";
@@ -76,7 +76,9 @@ export const MemberCollections = ({ member }: Props) => {
             ) : (
                 <MembersGrid members={members || []}>
                     {(member) => (
-                        <MemberChip key={member.account} member={member} />
+                        <MemberChip key={member.account} member={member}>
+                            <MemberChipNFTBadges member={member} />
+                        </MemberChip>
                     )}
                 </MembersGrid>
             )}

--- a/packages/webapp/src/members/components/member-collections.tsx
+++ b/packages/webapp/src/members/components/member-collections.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 
 import { Button, Container, Heading, LoadingCard } from "_app";
+import { MemberChip, MembersGrid } from "members";
 
 import { getCollection, getCollectedBy } from "../api";
 import { MemberData } from "../interfaces";
-import { MembersGrid } from "./members-grid";
 
 interface Props {
     member: MemberData;
@@ -74,7 +74,11 @@ export const MemberCollections = ({ member }: Props) => {
             {isLoading ? (
                 <LoadingCard />
             ) : (
-                <MembersGrid members={members || []} />
+                <MembersGrid members={members || []}>
+                    {(member) => (
+                        <MemberChip key={member.account} member={member} />
+                    )}
+                </MembersGrid>
             )}
         </div>
     );

--- a/packages/webapp/src/members/components/members-grid.tsx
+++ b/packages/webapp/src/members/components/members-grid.tsx
@@ -1,171 +1,21 @@
 import React from "react";
-import Link from "next/link";
-import dayjs from "dayjs";
-import { FaGavel } from "react-icons/fa";
-
-import { assetToString, ipfsUrl } from "_app";
-import { atomicAssets, blockExplorerAccountBaseUrl } from "config";
 import { MemberData } from "../interfaces";
-import { ROUTES } from "_app/config";
 
 interface Props {
-    members: MemberData[];
-    dataTestId?: string;
+    members?: MemberData[];
+    children(
+        value: MemberData,
+        index: number,
+        array: MemberData[]
+    ): React.ReactNode;
 }
 
-const openInNewTab = (url: string) => {
-    const newWindow = window.open(url, "_blank", "noopener,noreferrer");
-    if (newWindow) newWindow.opener = null;
-};
-
-export const MembersGrid = ({ members, dataTestId }: Props) => {
+export const MembersGrid = ({ members, children }: Props) => {
     return (
-        <div
-            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px"
-            data-testid={dataTestId}
-        >
-            {(members.length &&
-                members.map((member) => (
-                    <MemberChip key={member.account} member={member} />
-                ))) ||
-                "No members to list."}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px">
+            {members?.length ? members.map(children) : "No members to list."}
         </div>
     );
 };
 
-export const MemberChip = ({ member }: { member: MemberData }) => {
-    const memberChip = (
-        <div
-            className="relative flex items-center p-2.5 bg-white hover:bg-gray-100 active:bg-gray-200 transition select-none"
-            style={{ boxShadow: "0 0 0 1px #e5e5e5" }}
-        >
-            <div className="flex space-x-2.5">
-                <MemberImage member={member} />
-                <div className="flex-1 flex flex-col justify-center group">
-                    <p className="text-xs text-gray-500 font-light">
-                        {member.createdAt === 0
-                            ? "not an eden member"
-                            : dayjs(member.createdAt).format("YYYY.MM.DD")}
-                    </p>
-                    <p className="group-hover:underline">{member.name}</p>
-                    {member.account && (
-                        <p className="text-xs text-gray-500 font-light">
-                            @{member.account}
-                        </p>
-                    )}
-                </div>
-            </div>
-            <NFTBadges member={member} />
-        </div>
-    );
-
-    if (member.account) {
-        return (
-            <Link href={`${ROUTES.MEMBERS.href}/${member.account}`}>
-                <a>{memberChip}</a>
-            </Link>
-        );
-    }
-    return (
-        <a
-            href={`${blockExplorerAccountBaseUrl}/${member.name}`}
-            target="_blank"
-            rel="noopener noreferrer"
-        >
-            {memberChip}
-        </a>
-    );
-};
-
-const MemberImage = ({ member }: { member: MemberData }) => {
-    const imageClass = "rounded-full h-14 w-14 object-cover shadow";
-    if (member.account && member.image) {
-        return (
-            <div className="relative group">
-                <img src={ipfsUrl(member.image)} className={imageClass} />
-                <div className="absolute inset-0 bg-black opacity-0 group-hover:opacity-20 transition rounded-full" />
-            </div>
-        );
-    }
-    return <img src={"/images/unknown-member.png"} className={imageClass} />;
-};
-
-const NFTBadges = ({ member }: { member: MemberData }) => (
-    <div className="absolute right-0 bottom-0 p-2.5 space-y-0.5">
-        <AuctionBadge member={member} />
-        <SaleBadge member={member} />
-        {!member.auctionData && !member.saleId && (
-            <AssetBadge member={member} />
-        )}
-    </div>
-);
-
-const AssetBadge = ({ member }: { member: MemberData }) => {
-    if (member.assetData) {
-        return (
-            <div
-                className="group flex justify-end items-center space-x-1"
-                onClick={(e) => {
-                    e.preventDefault();
-                    openInNewTab(
-                        `${atomicAssets.hubUrl}/explorer/asset/${member?.assetData?.assetId}`
-                    );
-                }}
-            >
-                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
-                    NFT #{member.assetData.templateMint}
-                </p>
-            </div>
-        );
-    }
-    return <></>;
-};
-
-const AuctionBadge = ({ member }: { member: MemberData }) => {
-    if (member.auctionData) {
-        return (
-            <div
-                className="group flex justify-end items-center space-x-1"
-                onClick={(e) => {
-                    e.preventDefault();
-                    openInNewTab(
-                        `${atomicAssets.hubUrl}/market/auction/${member?.auctionData?.auctionId}`
-                    );
-                }}
-            >
-                <FaGavel
-                    size={14}
-                    className="text-gray-600 group-hover:text-gray-800"
-                />
-                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
-                    {assetToString(member.auctionData.price, 2)} (#
-                    {member.assetData?.templateMint})
-                </p>
-            </div>
-        );
-    }
-
-    return <></>;
-};
-
-const SaleBadge = ({ member }: { member: MemberData }) => {
-    if (member.saleId) {
-        return (
-            <div
-                className="group flex justify-end items-center space-x-1"
-                onClick={(e) => {
-                    e.preventDefault();
-                    openInNewTab(
-                        `${atomicAssets.hubUrl}/market/sale/${member.saleId}`
-                    );
-                }}
-            >
-                <p className="text-sm tracking-tight leading-none p-t-px group-hover:underline">
-                    ON SALE (#
-                    {member.assetData?.templateMint})
-                </p>
-            </div>
-        );
-    }
-    return <></>;
-};
+export default MembersGrid;

--- a/packages/webapp/src/pages/election-components/index.tsx
+++ b/packages/webapp/src/pages/election-components/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import { GetServerSideProps } from "next";
+import { QueryClient, useQuery } from "react-query";
+import { dehydrate } from "react-query/hydration";
+import { FaRegSquare, FaSquare } from "react-icons/fa";
+
+import {
+    Container,
+    FluidLayout,
+    Heading,
+    queryMembersStats,
+    queryMembers,
+} from "_app";
+import { MemberChip, MembersGrid } from "members";
+import { MemberData } from "members/interfaces";
+
+const MEMBERS_PAGE_SIZE = 18;
+
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+    const queryClient = new QueryClient();
+
+    const membersPage = parseInt((query.membersPage as string) || "1");
+
+    await Promise.all([
+        queryClient.prefetchQuery(queryMembersStats),
+        queryClient.prefetchQuery(queryMembers(membersPage, MEMBERS_PAGE_SIZE)),
+    ]);
+
+    return {
+        props: {
+            dehydratedState: dehydrate(queryClient),
+            membersPage,
+        },
+    };
+};
+
+interface Props {
+    membersPage: number;
+}
+
+export const MembersPage = (props: Props) => {
+    const [selectedMember, setSelected] = useState<string | null>(null);
+
+    const members = useQuery({
+        ...queryMembers(props.membersPage, MEMBERS_PAGE_SIZE),
+        keepPreviousData: true,
+    });
+
+    const handleMemberClick = (e: React.MouseEvent, member: MemberData) => {
+        setSelected(member.account);
+    };
+
+    return (
+        <FluidLayout title="Community">
+            <Container>
+                <Heading size={1}>Group 1</Heading>
+                {members.isLoading && "Loading members..."}
+                {members.error && "Fail to load members"}
+            </Container>
+            <MembersGrid members={members.data}>
+                {(member) => (
+                    <MemberChip
+                        key={member.account}
+                        member={member}
+                        onClickChip={(e) => handleMemberClick(e, member)}
+                        onClickProfileImage={(e) =>
+                            handleMemberClick(e, member)
+                        }
+                    >
+                        {selectedMember === member.account ? (
+                            <FaSquare
+                                size={31}
+                                className="text-gray-600 hover:text-gray-700"
+                            />
+                        ) : (
+                            <FaRegSquare
+                                size={31}
+                                className="text-gray-300 hover:text-gray-400"
+                            />
+                        )}
+                    </MemberChip>
+                )}
+            </MembersGrid>
+        </FluidLayout>
+    );
+};
+
+export default MembersPage;

--- a/packages/webapp/src/pages/election/components.tsx
+++ b/packages/webapp/src/pages/election/components.tsx
@@ -2,23 +2,16 @@ import React, { useState } from "react";
 import { GetServerSideProps } from "next";
 import { QueryClient, useQuery } from "react-query";
 import { dehydrate } from "react-query/hydration";
-import { FaRegSquare, FaSquare } from "react-icons/fa";
 
-import {
-    Container,
-    FluidLayout,
-    Heading,
-    queryMembersStats,
-    queryMembers,
-} from "_app";
-import { MemberChip, MembersGrid } from "members";
-import { MemberData } from "members/interfaces";
+import { FluidLayout, queryMembersStats, queryMembers } from "_app";
+import { Container, Heading } from "_app/ui";
+import { MembersGrid } from "members";
+import { VotingMemberChip, WinningMemberChip } from "elections";
 
 const MEMBERS_PAGE_SIZE = 18;
 
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
     const queryClient = new QueryClient();
-
     const membersPage = parseInt((query.membersPage as string) || "1");
 
     await Promise.all([
@@ -46,39 +39,31 @@ export const MembersPage = (props: Props) => {
         keepPreviousData: true,
     });
 
-    const handleMemberClick = (e: React.MouseEvent, member: MemberData) => {
-        setSelected(member.account);
-    };
-
     return (
         <FluidLayout title="Community">
-            <Container>
-                <Heading size={1}>Group 1</Heading>
+            <Container className="pt-6 border-b">
+                <Heading size={1}>Voting Chips</Heading>
                 {members.isLoading && "Loading members..."}
                 {members.error && "Fail to load members"}
             </Container>
             <MembersGrid members={members.data}>
                 {(member) => (
-                    <MemberChip
+                    <VotingMemberChip
                         key={member.account}
                         member={member}
-                        onClickChip={(e) => handleMemberClick(e, member)}
-                        onClickProfileImage={(e) =>
-                            handleMemberClick(e, member)
-                        }
-                    >
-                        {selectedMember === member.account ? (
-                            <FaSquare
-                                size={31}
-                                className="text-gray-600 hover:text-gray-700"
-                            />
-                        ) : (
-                            <FaRegSquare
-                                size={31}
-                                className="text-gray-300 hover:text-gray-400"
-                            />
-                        )}
-                    </MemberChip>
+                        isSelected={selectedMember === member.account}
+                        onSelect={() => setSelected(member.account)}
+                    />
+                )}
+            </MembersGrid>
+            <Container className="pt-6 border-t border-b">
+                <Heading size={1}>Winner Chip</Heading>
+                {members.isLoading && "Loading members..."}
+                {members.error && "Fail to load members"}
+            </Container>
+            <MembersGrid members={members.data?.slice(1, 2)}>
+                {(member) => (
+                    <WinningMemberChip key={member.account} member={member} />
                 )}
             </MembersGrid>
         </FluidLayout>

--- a/packages/webapp/src/pages/members/index.tsx
+++ b/packages/webapp/src/pages/members/index.tsx
@@ -13,7 +13,7 @@ import {
     queryMembers,
     queryNewMembers,
 } from "_app";
-import { MemberChip, MembersGrid } from "members";
+import { MemberChip, MemberChipNFTBadges, MembersGrid } from "members";
 
 const MEMBERS_PAGE_SIZE = 18;
 const NEW_MEMBERS_PAGE_SIZE = 12;
@@ -106,7 +106,9 @@ export const MembersPage = (props: Props) => {
                                 <MemberChip
                                     key={member.account}
                                     member={member}
-                                />
+                                >
+                                    <MemberChipNFTBadges member={member} />
+                                </MemberChip>
                             )}
                         </MembersGrid>
                     </div>

--- a/packages/webapp/src/pages/members/index.tsx
+++ b/packages/webapp/src/pages/members/index.tsx
@@ -13,7 +13,7 @@ import {
     queryMembers,
     queryNewMembers,
 } from "_app";
-import { MembersGrid } from "members";
+import { MemberChip, MembersGrid } from "members";
 
 const MEMBERS_PAGE_SIZE = 18;
 const NEW_MEMBERS_PAGE_SIZE = 12;
@@ -101,10 +101,14 @@ export const MembersPage = (props: Props) => {
             {newMembers.data && (
                 <>
                     <div className="border-t border-b">
-                        <MembersGrid
-                            members={newMembers.data}
-                            dataTestId="new-members-grid"
-                        />
+                        <MembersGrid members={newMembers.data}>
+                            {(member) => (
+                                <MemberChip
+                                    key={member.account}
+                                    member={member}
+                                />
+                            )}
+                        </MembersGrid>
                     </div>
                     <Container>
                         <PaginationNav
@@ -125,10 +129,14 @@ export const MembersPage = (props: Props) => {
             {members.data && (
                 <>
                     <div className="border-t border-b">
-                        <MembersGrid
-                            members={members.data}
-                            dataTestId="members-grid"
-                        />
+                        <MembersGrid members={members.data}>
+                            {(member) => (
+                                <MemberChip
+                                    key={member.account}
+                                    member={member}
+                                />
+                            )}
+                        </MembersGrid>
                     </div>
                     <Container>
                         <PaginationNav

--- a/packages/webapp/src/pages/members/index.tsx
+++ b/packages/webapp/src/pages/members/index.tsx
@@ -13,7 +13,7 @@ import {
     queryMembers,
     queryNewMembers,
 } from "_app";
-import { MemberChip, MemberChipNFTBadges, MembersGrid } from "members";
+import { MemberChip, MembersGrid } from "members";
 
 const MEMBERS_PAGE_SIZE = 18;
 const NEW_MEMBERS_PAGE_SIZE = 12;
@@ -106,9 +106,7 @@ export const MembersPage = (props: Props) => {
                                 <MemberChip
                                     key={member.account}
                                     member={member}
-                                >
-                                    <MemberChipNFTBadges member={member} />
-                                </MemberChip>
+                                />
                             )}
                         </MembersGrid>
                     </div>


### PR DESCRIPTION
Creates a `GenericMemberChip` component that is used by three new specific member chip components/permutations:

* `MemberChip`
* `VotingMemberChip`
* `WinningMemberChip`

These can be seen in action on the members pages and in a new page: `/election/components`.

![image](https://user-images.githubusercontent.com/7911424/125861291-b404a95c-34a1-448c-bfe9-529971f59de5.png)

![image](https://user-images.githubusercontent.com/7911424/125861321-0fdfc53a-ade4-4ca8-bca7-e632030a6727.png)