### PR TITLE
Fixing example cypress tests

### DIFF
--- a/packages/webapp/cypress/integration/community.spec.ts
+++ b/packages/webapp/cypress/integration/community.spec.ts
@@ -9,7 +9,7 @@ describe("Community", () => {
         expect(newMembersGrid).to.exist;
         const membersGrid = cy.get(`[data-testid="members-grid"]`);
         expect(membersGrid).to.exist;
-        membersGrid.find("a").should("have.length.greaterThan", 0);
+        membersGrid.find("div").should("have.length.greaterThan", 0);
     });
 
     it("should allow to view a member profile", () => {

--- a/packages/webapp/src/members/components/members-grid.tsx
+++ b/packages/webapp/src/members/components/members-grid.tsx
@@ -3,6 +3,7 @@ import { MemberData } from "../interfaces";
 
 interface Props {
     members?: MemberData[];
+    dataTestId?: string;
     children(
         value: MemberData,
         index: number,
@@ -10,9 +11,12 @@ interface Props {
     ): React.ReactNode;
 }
 
-export const MembersGrid = ({ members, children }: Props) => {
+export const MembersGrid = ({ members, dataTestId, children }: Props) => {
     return (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px">
+        <div
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-px"
+            data-testid={dataTestId}
+        >
             {members?.length ? members.map(children) : "No members to list."}
         </div>
     );

--- a/packages/webapp/src/pages/members/index.tsx
+++ b/packages/webapp/src/pages/members/index.tsx
@@ -101,7 +101,10 @@ export const MembersPage = (props: Props) => {
             {newMembers.data && (
                 <>
                     <div className="border-t border-b">
-                        <MembersGrid members={newMembers.data}>
+                        <MembersGrid
+                            members={newMembers.data}
+                            dataTestId="new-members-grid"
+                        >
                             {(member) => (
                                 <MemberChip
                                     key={member.account}
@@ -129,7 +132,10 @@ export const MembersPage = (props: Props) => {
             {members.data && (
                 <>
                     <div className="border-t border-b">
-                        <MembersGrid members={members.data}>
+                        <MembersGrid
+                            members={members.data}
+                            dataTestId="members-grid"
+                        >
                             {(member) => (
                                 <MemberChip
                                     key={member.account}


### PR DESCRIPTION
In my prior PRs implementing the new member chip designs, I removed some of the `data-testid` props Cypress was looking for. I replaced those. Also fixed one other issue with the Cypress tests.

These are just introductory example tests, but worth keeping up nonetheless.