### PR TITLE
intRA-round member grouping

### DIFF
--- a/packages/webapp/cypress/integration/community.spec.ts
+++ b/packages/webapp/cypress/integration/community.spec.ts
@@ -19,7 +19,9 @@ describe("Community", () => {
             .first();
         firstMember.click();
 
-        const memberCard = cy.get(`[data-testid^="member-card-"]`);
+        const memberCard = cy.get(`[data-testid^="member-card-"]`, {
+            timeout: 30000,
+        });
         expect(memberCard).to.exist;
 
         cy.get("head title").should("contain", `'s Profile`);

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -28,6 +28,8 @@ import {
     getCurrentElection,
     getElectionState,
     getMemberGroupParticipants,
+    getVoteData,
+    getVoteDataRow,
 } from "elections/api/eden-contract";
 import { ActiveStateConfigType } from "elections/interfaces";
 
@@ -54,8 +56,21 @@ export const queryMemberGroupParticipants = (
 ) => ({
     queryKey: ["query_member_group_participants", memberAccount, config],
     queryFn: () => getMemberGroupParticipants(memberAccount, config),
+    enabled: Boolean(memberAccount),
 });
 
+export const queryVoteData = {
+    queryKey: "query_vote_data",
+    queryFn: getVoteData,
+};
+
+export const queryVoteDataRow = (account: string | undefined) => ({
+    queryKey: ["query_vote_data_row", account],
+    queryFn: () =>
+        getVoteDataRow(
+            account ? { fieldName: "member", fieldValue: account } : undefined
+        ),
+});
 export const queryCurrentElection = {
     queryKey: "query_current_election",
     queryFn: getCurrentElection,
@@ -215,3 +230,15 @@ export const useMemberStats = () =>
     useQuery({
         ...queryMembersStats,
     });
+
+export const useVoteData = () =>
+    useQuery({
+        ...queryCurrentElection,
+    });
+
+export const useVoteDataRow = (account: string | undefined) => {
+    return useQuery({
+        ...queryVoteDataRow(account),
+        enabled: Boolean(account),
+    });
+};

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -28,7 +28,6 @@ import {
     getCurrentElection,
     getElectionState,
     getMemberGroupParticipants,
-    getVoteData,
     getVoteDataRow,
 } from "elections/api/eden-contract";
 import { ActiveStateConfigType } from "elections/interfaces";
@@ -58,11 +57,6 @@ export const queryMemberGroupParticipants = (
     queryFn: () => getMemberGroupParticipants(memberAccount, config),
     enabled: Boolean(memberAccount),
 });
-
-export const queryVoteData = {
-    queryKey: "query_vote_data",
-    queryFn: getVoteData,
-};
 
 export const queryVoteDataRow = (account: string | undefined) => ({
     queryKey: ["query_vote_data_row", account],
@@ -229,11 +223,6 @@ export const useElectionState = () =>
 export const useMemberStats = () =>
     useQuery({
         ...queryMembersStats,
-    });
-
-export const useVoteData = () =>
-    useQuery({
-        ...queryCurrentElection,
     });
 
 export const useVoteDataRow = (account: string | undefined) => {

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -42,7 +42,7 @@ export const queryChiefDelegates = {
     queryFn: getChiefDelegates,
 };
 
-export const queryMyDelegation = (memberAccount: string) => ({
+export const queryMyDelegation = (memberAccount?: string) => ({
     queryKey: ["query_my_delegation", memberAccount],
     queryFn: () => getMyDelegation(memberAccount),
 });

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -42,28 +42,29 @@ export const queryChiefDelegates = {
     queryFn: getChiefDelegates,
 };
 
-export const queryMyDelegation = (
-    loggedInMemberAccount: string | undefined
-) => ({
-    queryKey: ["query_my_delegation", loggedInMemberAccount],
-    queryFn: () => getMyDelegation(loggedInMemberAccount),
+export const queryMyDelegation = (memberAccount: string) => ({
+    queryKey: ["query_my_delegation", memberAccount],
+    queryFn: () => getMyDelegation(memberAccount),
 });
 
 export const queryMemberGroupParticipants = (
-    memberAccount: string | undefined,
-    config: ActiveStateConfigType
+    memberAccount?: string,
+    config?: ActiveStateConfigType
 ) => ({
     queryKey: ["query_member_group_participants", memberAccount, config],
     queryFn: () => getMemberGroupParticipants(memberAccount, config),
-    enabled: Boolean(memberAccount),
+    enabled: Boolean(memberAccount && config),
 });
 
-export const queryVoteDataRow = (account: string | undefined) => ({
+export const queryVoteDataRow = (account?: string) => ({
     queryKey: ["query_vote_data_row", account],
-    queryFn: () =>
-        getVoteDataRow(
-            account ? { fieldName: "member", fieldValue: account } : undefined
-        ),
+    queryFn: () => {
+        if (!account)
+            throw new Error(
+                "getVoteDataRow requires an account (got 'undefined')"
+            );
+        return getVoteDataRow({ fieldName: "member", fieldValue: account });
+    },
 });
 export const queryCurrentElection = {
     queryKey: "query_current_election",
@@ -202,16 +203,11 @@ export const useCurrentElection = () =>
         ...queryCurrentElection,
     });
 
-export const useMemberGroupParticipants = (
-    loggedInMemberAccount: string | undefined
-) => {
+export const useMemberGroupParticipants = (memberAccount?: string) => {
     const { data: currentElection } = useCurrentElection();
     return useQuery({
-        ...queryMemberGroupParticipants(
-            loggedInMemberAccount,
-            currentElection?.config
-        ),
-        enabled: Boolean(loggedInMemberAccount && currentElection?.config),
+        ...queryMemberGroupParticipants(memberAccount, currentElection?.config),
+        enabled: Boolean(memberAccount && currentElection?.config),
     });
 };
 
@@ -225,7 +221,7 @@ export const useMemberStats = () =>
         ...queryMembersStats,
     });
 
-export const useVoteDataRow = (account: string | undefined) => {
+export const useVoteDataRow = (account?: string) => {
     return useQuery({
         ...queryVoteDataRow(account),
         enabled: Boolean(account),

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -60,10 +60,17 @@ const getMemberGroupFromIndex = (
 };
 
 export const getMemberGroupParticipants = async (
-    memberAccount: string | undefined,
-    config: ActiveStateConfigType
+    memberAccount?: string,
+    config?: ActiveStateConfigType
 ) => {
-    if (!memberAccount || !config) return undefined;
+    if (!config)
+        throw new Error(
+            "getMemberGroupParticipants requires a config object (got 'undefined')"
+        );
+    if (!memberAccount)
+        throw new Error(
+            "getMemberGroupParticipants requires an account (got 'undefined')"
+        );
 
     const totalParticipants = config.num_participants;
     const numGroups = config.num_groups;
@@ -96,9 +103,8 @@ export const getMemberGroupParticipants = async (
 };
 
 export const getVoteDataRow = async (
-    opts?: VoteDataQueryOptionsByField
+    opts: VoteDataQueryOptionsByField
 ): Promise<VoteData | undefined> => {
-    if (!opts) return undefined;
     if (devUseFixtureData)
         return Promise.resolve(fixtureVoteDataRow(opts.fieldValue));
 

--- a/packages/webapp/src/elections/api/fixtures.ts
+++ b/packages/webapp/src/elections/api/fixtures.ts
@@ -1,4 +1,3 @@
-import { getChiefDelegates } from "delegates/api";
 import { CurrentElection, ElectionState, VoteData } from "elections/interfaces";
 
 // The following fixtures represent the following Election/round layout
@@ -46,37 +45,55 @@ export const fixtureCurrentElection: CurrentElection = {
     round_end: "time string",
 };
 
-// This data represents the *first* round (whereas other fixture data represents the *results* of the overall election)
+// This data represents the *in-progress*, *first* round (whereas other fixture data represents the *results* of the overall election)
 export const fixtureVoteDataRows: VoteData[] = [
     {
-        member: "egeon.edev",
+        member: "edenmember11",
         round: 1,
-        index: 1,
-        candidate: "edenmember13",
+        index: 0,
+        candidate: "edenmember12",
     },
     {
         member: "edenmember12",
         round: 1,
-        index: 2,
-        candidate: "edenmember13",
+        index: 1,
+        candidate: "edenmember12",
     },
     {
         member: "edenmember13",
         round: 1,
+        index: 2,
+        candidate: "edenmember14",
+    },
+    {
+        member: "edenmember14",
+        round: 1,
         index: 3,
+        candidate: "edenmember14",
+    },
+    {
+        member: "edenmember15",
+        round: 1,
+        index: 4,
+        candidate: "egeon.edev",
+    },
+    {
+        member: "egeon.edev",
+        round: 1,
+        index: 5,
         candidate: "edenmember13",
+    },
+    {
+        member: "edenmember21",
+        round: 1,
+        index: 6,
+        candidate: "pip.edev",
     },
     {
         member: "pip.edev",
         round: 1,
-        index: 4,
-        candidate: "edenmember11",
-    },
-    {
-        member: "edenmember11",
-        round: 1,
-        index: 5,
-        candidate: "edenmember11",
+        index: 7,
+        candidate: "pip.edev",
     },
 ];
 

--- a/packages/webapp/src/members/interfaces.ts
+++ b/packages/webapp/src/members/interfaces.ts
@@ -8,7 +8,7 @@ export type VoteDataQueryOptionsByGroup = {
 };
 
 export type VoteDataQueryOptionsByField = {
-    fieldName?: "name";
+    fieldName?: string;
     fieldValue: string;
 };
 

--- a/packages/webapp/src/pages/election/data.tsx
+++ b/packages/webapp/src/pages/election/data.tsx
@@ -153,11 +153,13 @@ export const ElectionPage = () => {
                     currentElectionState[active].round[{currentElection.round}]
                 </Text>
                 <Text>
+                    If this member not in `vote` table then their participation
+                    in the election is complete, and you can find their group
+                    (hierarchical arrangement) data in the `member`.
+                </Text>
+                <Text>
                     voteRow for currently-logged-in member [
-                    {loggedInMember.account}]. If this member not in `vote`
-                    table then their participation in the election is complete,
-                    and you can find their group (hierarchical arrangement) data
-                    in the member table:
+                    {loggedInMember.account}]:
                 </Text>
                 <pre>{JSON.stringify(rawVoteDataRow || {}, null, 2)}</pre>
                 <Text>
@@ -181,12 +183,13 @@ export const ElectionPage = () => {
                 <Text>Target Round: {targetElectionRound}</Text>
                 <pre>{JSON.stringify(data, null, 2)}</pre>
             </DataExpander> */}
-            <DataExpander title="Who's in the current Round? -- INTER-round group data">
+            <DataExpander title="Who's in the current Round? -- post-round group data">
                 <Text size="sm">
                     Who voted for whom is *only* available during the active
                     round. That info is *not* stored long-term in tables. We'll
                     need a history solution to look at the history of who voted
-                    for whom.
+                    for whom. So as soon as a round is over (during an election
+                    or long after), this scenario will apply.
                 </Text>
                 <Text size="sm">
                     And... vote info will only be available while the property

--- a/packages/webapp/src/pages/election/data.tsx
+++ b/packages/webapp/src/pages/election/data.tsx
@@ -22,10 +22,6 @@ export const ElectionPage = () => {
 
     const { data: currentElection } = useCurrentElection();
 
-    const { data: voteData } = useMemberGroupParticipants(
-        loggedInMember?.account
-    );
-
     const { data: rawVoteDataRow } = useVoteDataRow(loggedInMember?.account);
 
     const { data: membersInGroup } = useMemberGroupParticipants(
@@ -53,13 +49,13 @@ export const ElectionPage = () => {
             currentElection.election_seeder.end_time) ||
             currentElection.start_time);
 
-    if (!loggedInMember || !currentElection || !voteData) {
+    if (!loggedInMember || !currentElection) {
         return (
             <FluidLayout>
                 <Text size="lg">
                     Fetching Data loggedInMember: [{Boolean(loggedInMember)}],
-                    voteData[
-                    {Boolean(voteData)}], currentElection[
+                    rawVoteData[
+                    {Boolean(rawVoteDataRow)}], currentElection[
                     {Boolean(currentElection)}]...
                 </Text>
                 <div>
@@ -67,7 +63,6 @@ export const ElectionPage = () => {
                         "The logged-in member is not part of the deployed member base. Log in as another user, eg. pip.edev, egeon.edev"}
                 </div>
                 [<pre>{JSON.stringify(loggedInMember, null, 2)}</pre>] [
-                <pre>{JSON.stringify(voteData, null, 2)}</pre>] [
                 <pre>{JSON.stringify(currentElection, null, 2)}</pre>]
             </FluidLayout>
         );
@@ -146,9 +141,26 @@ export const ElectionPage = () => {
                 startExpanded={true}
             >
                 <Text>All grouping info comes from `vote` table</Text>
-                {/* <Text>Target Round: {targetElectionRound}</Text> */}
-
-                <Text>We know the *current* round from this field</Text>
+                <Text size="sm">
+                    Who voted for whom is *only* available during the active
+                    round. That info is *not* stored long-term in tables. We'll
+                    need a history solution to look at the history of who voted
+                    for whom. So as soon as a round is over (during an election
+                    or long after), this scenario will apply.
+                </Text>
+                <Text size="sm">
+                    And... vote info will only be available while the property
+                    'electionState' is 'active'. NOTE: this 'active' field is
+                    the underlying variant type. It's meta info... the first
+                    field in the array-encoding we get back for table rows. See
+                    code for details if interested; or be thankful you don't
+                    need to know more than this note... :)
+                </Text>
+                Is there leaderboard / voting info available right now? ie. is
+                electionState 'active'?
+                <pre>[{currentElection.electionState}]</pre>
+                <Text>Everything below assume `electionState === active`</Text>
+                <Text>We know the *current* round from this field:</Text>
                 <Text>
                     currentElectionState[active].round[{currentElection.round}]
                 </Text>
@@ -183,45 +195,16 @@ export const ElectionPage = () => {
                 <Text>Target Round: {targetElectionRound}</Text>
                 <pre>{JSON.stringify(data, null, 2)}</pre>
             </DataExpander> */}
-            <DataExpander title="Who's in the current Round? -- post-round group data">
-                <Text size="sm">
-                    Who voted for whom is *only* available during the active
-                    round. That info is *not* stored long-term in tables. We'll
-                    need a history solution to look at the history of who voted
-                    for whom. So as soon as a round is over (during an election
-                    or long after), this scenario will apply.
-                </Text>
-                <Text size="sm">
-                    And... vote info will only be available while the property
-                    'electionState' is 'active'. NOTE: this 'active' field is
-                    the underlying variant type. It's meta info... the first
-                    field in the array-encoding we get back for table rows. See
-                    code for details if interested; or be thankful you don't
-                    need to know more than this note... :)
-                </Text>
-                Is there leaderboard / voting info available right now? ie. is
-                electionState 'active'?
-                <pre>[{currentElection.electionState}]</pre>
-                <pre>
-                    If active, here are the participants in your
-                    current/in-progress/up-coming round (represents Round 1 of
-                    the election):
-                </pre>
-                <pre>{JSON.stringify(voteData, null, 2)}</pre>
-                {/* <pre>{`voteData.isLoading[${isLoading}], isError[${isError}]`}</pre> */}
+            <DataExpander title="Who was in a particular previous Round? -- post-round group data">
                 <Text>The Logic:</Text>
                 <Text>
                     if member isn't in the vote, table, that means they're no
                     longer participating in a round, and we'll find their group
-                    data in the `membrers` table
+                    data in the `members` table
                 </Text>
-                <pre>
-                    results from `vote` table where row is member.name ={" "}
-                    {loggedInMember.account}
-                </pre>
                 <Text>
-                    Then look in the members table to build their group from
-                    members data
+                    results from `vote` table where row is member.name[
+                    {loggedInMember.account}]
                 </Text>
                 <Text>
                     Then look in the members table to build their group from

--- a/packages/webapp/src/pages/election/data.tsx
+++ b/packages/webapp/src/pages/election/data.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 
 import {
+    Container,
     ElectionParticipationStatus,
+    Expander,
+    FluidLayout,
     RawLayout,
     Text,
     useCurrentElection,
@@ -9,6 +12,7 @@ import {
     useElectionState,
     useHeadDelegate,
     useMemberGroupParticipants,
+    useVoteDataRow,
 } from "_app";
 
 export const ElectionPage = () => {
@@ -22,6 +26,12 @@ export const ElectionPage = () => {
         loggedInMember?.account
     );
 
+    const { data: rawVoteDataRow } = useVoteDataRow(loggedInMember?.account);
+
+    const { data: membersInGroup } = useMemberGroupParticipants(
+        loggedInMember?.account
+    );
+
     const {
         isError: isElectionStateDataFetchError,
         data: electionState,
@@ -29,9 +39,11 @@ export const ElectionPage = () => {
 
     if (isElectionStateDataFetchError) {
         return (
-            <Text className="text-red-500">
-                Error fetching Current Election data...
-            </Text>
+            <FluidLayout>
+                <Text className="text-red-500">
+                    Error fetching Current Election data...
+                </Text>
+            </FluidLayout>
         );
     }
 
@@ -43,7 +55,7 @@ export const ElectionPage = () => {
 
     if (!loggedInMember || !currentElection || !voteData) {
         return (
-            <>
+            <FluidLayout>
                 <Text size="lg">
                     Fetching Data loggedInMember: [{Boolean(loggedInMember)}],
                     voteData[
@@ -57,9 +69,10 @@ export const ElectionPage = () => {
                 [<pre>{JSON.stringify(loggedInMember, null, 2)}</pre>] [
                 <pre>{JSON.stringify(voteData, null, 2)}</pre>] [
                 <pre>{JSON.stringify(currentElection, null, 2)}</pre>]
-            </>
+            </FluidLayout>
         );
     }
+
     return (
         <RawLayout title="Election">
             <Text size="sm" className="mb-8">
@@ -69,10 +82,7 @@ export const ElectionPage = () => {
             <Text size="lg" className="bg-gray-200">
                 Current Election
             </Text>
-            <div>
-                <Text size="lg" className="mb-4 mt-4">
-                    Election Start Date/Time
-                </Text>
+            <DataExpander title="Election Start Date/Time">
                 <div>
                     <Text
                         size="lg"
@@ -103,17 +113,14 @@ export const ElectionPage = () => {
                     </Text>
                     <pre>[{electionStartDateTime}]</pre>
                 </div>
-            </div>
-            <div>
-                <Text size="lg" className="mt-8">
-                    About Previous (completed) Election:
-                </Text>
+            </DataExpander>
+            <DataExpander title="About Previous (completed) Election:">
                 <Text size="sm">Head Chief Delegate:</Text>
                 <pre>[{leadRepresentative}]</pre>
                 <Text size="sm">Chief Delegates:</Text>
                 <pre>[{electionState && electionState.board.toString()}]</pre>
-            </div>
-            <div>
+            </DataExpander>
+            <DataExpander title="About Previous (completed) Election:">
                 <Text size="lg" className="mt-8">
                     RSVP Status
                 </Text>
@@ -133,11 +140,48 @@ export const ElectionPage = () => {
                         : "<error>"}
                     ]
                 </pre>
-            </div>
-            <div>
-                <Text size="lg" className="mt-8">
-                    Upcoming groups and participants
+            </DataExpander>
+            <DataExpander
+                title="Who's in the current Round? -- INTRA-round group data"
+                startExpanded={true}
+            >
+                <Text>All grouping info comes from `vote` table</Text>
+                {/* <Text>Target Round: {targetElectionRound}</Text> */}
+
+                <Text>We know the *current* round from this field</Text>
+                <Text>
+                    currentElectionState[active].round[{currentElection.round}]
                 </Text>
+                <Text>
+                    voteRow for currently-logged-in member [
+                    {loggedInMember.account}]. If this member not in `vote`
+                    table then their participation in the election is complete,
+                    and you can find their group (hierarchical arrangement) data
+                    in the member table:
+                </Text>
+                <pre>{JSON.stringify(rawVoteDataRow || {}, null, 2)}</pre>
+                <Text>
+                    if member is found in `vote` table, take their `index` and
+                    search for others with `index` values that have been
+                    assigned to the same group. member.index [
+                    {rawVoteDataRow?.index}]
+                </Text>
+                <Text>
+                    if member is found in `vote` table, search for others in
+                    their group using `useMemberGroupParticipants(), which
+                    return an EdenMember[]`
+                </Text>
+                <pre>{JSON.stringify(membersInGroup || {}, null, 2)}</pre>
+            </DataExpander>
+            {/* <DataExpander
+                title="Who's in what Round? -- inter-election"
+                startExpanded={true}
+            >
+                <Text>All grouping info comes from members table</Text>
+                <Text>Target Round: {targetElectionRound}</Text>
+                <pre>{JSON.stringify(data, null, 2)}</pre>
+            </DataExpander> */}
+            <DataExpander title="Who's in the current Round? -- INTER-round group data">
                 <Text size="sm">
                     Who voted for whom is *only* available during the active
                     round. That info is *not* stored long-term in tables. We'll
@@ -161,34 +205,62 @@ export const ElectionPage = () => {
                     the election):
                 </pre>
                 <pre>{JSON.stringify(voteData, null, 2)}</pre>
-            </div>
-
-            <Text size="lg" className="bg-gray-200 mt-16">
-                Original
-            </Text>
-            <div className="grid grid-cols-2">
-                <div>
-                    <Text size="lg" className="mb-4">
-                        -- Raw Table Data --
-                    </Text>
-                    <div>
-                        <Text size="lg" className="mt-4">
-                            Current Election
-                        </Text>
-                        <pre>{JSON.stringify(currentElection, null, 2)}</pre>
-                    </div>
-                    <div>
-                        <Text size="lg" className="mt-4">
-                            Election State
-                        </Text>
-                        <pre>
-                            {JSON.stringify(electionState || {}, null, 2)}
-                        </pre>
-                    </div>
-                </div>
+                {/* <pre>{`voteData.isLoading[${isLoading}], isError[${isError}]`}</pre> */}
+                <Text>The Logic:</Text>
+                <Text>
+                    if member isn't in the vote, table, that means they're no
+                    longer participating in a round, and we'll find their group
+                    data in the `membrers` table
+                </Text>
+                <pre>
+                    results from `vote` table where row is member.name ={" "}
+                    {loggedInMember.account}
+                </pre>
+                <Text>
+                    Then look in the members table to build their group from
+                    members data
+                </Text>
+                <Text>
+                    Then look in the members table to build their group from
+                    members data
+                </Text>
+            </DataExpander>
+            <div>
+                <Text size="lg" className="bg-gray-200 mt-16">
+                    Original -- Raw Table Data --
+                </Text>
+                <DataExpander title="Current Election">
+                    <pre>{JSON.stringify(currentElection, null, 2)}</pre>
+                </DataExpander>
+                <DataExpander title="Election State">
+                    <pre>{JSON.stringify(electionState || {}, null, 2)}</pre>
+                </DataExpander>
             </div>
         </RawLayout>
     );
 };
+
+interface DataExpanderProps {
+    title: string;
+    children: React.ReactNode;
+    startExpanded?: boolean;
+}
+
+const DataExpander = ({
+    title,
+    startExpanded,
+    children,
+}: DataExpanderProps) => (
+    <Expander
+        header={
+            <div className="flex justify-center items-center space-x-2">
+                <Text className="font-semibold">{title}</Text>
+            </div>
+        }
+        startExpanded={startExpanded}
+    >
+        <Container>{children}</Container>
+    </Expander>
+);
 
 export default ElectionPage;


### PR DESCRIPTION
This PR adds to election/data.tsx to show the basics of getting member grouping **for** and **during** the round that's currently happening. A follow-on PR will handle the inter-election / previous-round scenarios.