### PR TITLE
Restyle password prompt banner; eliminate flicker.

### DIFF
--- a/packages/webapp/src/_app/layouts/fluid-layout.tsx
+++ b/packages/webapp/src/_app/layouts/fluid-layout.tsx
@@ -6,14 +6,21 @@ interface Props {
     title?: string;
     children: React.ReactNode;
     hideBorders?: boolean;
+    banner?: React.ReactNode;
 }
 
-export const FluidLayout = ({ children, title, hideBorders }: Props) => (
+export const FluidLayout = ({
+    children,
+    title,
+    hideBorders,
+    banner,
+}: Props) => (
     <div className="flex flex-col min-h-screen">
         <HeaderNav />
         <Head>
             <title>{title && `${title} | `} Eden</title>
         </Head>
+        {banner}
         <main className="flex-grow">
             <div className="max-w-screen-xl mx-auto">
                 <div

--- a/packages/webapp/src/_app/ui/button.tsx
+++ b/packages/webapp/src/_app/ui/button.tsx
@@ -28,6 +28,7 @@ export type ButtonType =
     | "primary"
     | "disabled"
     | "neutral"
+    | "caution"
     | "danger"
     | "dangerOutline"
     | "inductionStatusProfile"
@@ -38,6 +39,7 @@ const TYPES: { [key in ButtonType]: string } = {
     primary: "bg-blue-500 border-blue-500 text-white hover:bg-blue-600",
     disabled: "border-gray-400 bg-gray-300 text-gray-500",
     neutral: "bg-gray-50 text-gray-800 hover:bg-gray-200",
+    caution: "bg-yellow-500 text-white hover:bg-yellow-600 border-white",
     danger: "bg-red-500 text-white hover:bg-red-600",
     dangerOutline: "text-gray-500 hover:text-red-500 border-none",
     link: "border-transparent text-blue-500 hover:text-yellow-500",

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -11,9 +11,11 @@ export const OngoingElection = () => {
     const { data: currentElection } = useCurrentElection();
 
     return (
-        <FluidLayout title="Election">
+        <FluidLayout
+            title="Election"
+            banner={<EncryptionPasswordAlert promptSetupEncryptionKey />}
+        >
             <div className="divide-y">
-                <EncryptionPasswordAlert promptSetupEncryptionKey />
                 <Container>
                     <Heading size={1}>Election</Heading>
                 </Container>

--- a/packages/webapp/src/encryption/components/encryption-password-alert.tsx
+++ b/packages/webapp/src/encryption/components/encryption-password-alert.tsx
@@ -1,5 +1,6 @@
 import { PrivateKey } from "eosjs/dist/PrivateKey";
 import { useState } from "react";
+import { BsExclamationTriangle } from "react-icons/bs";
 
 import {
     Button,
@@ -29,6 +30,7 @@ export const EncryptionPasswordAlert = ({
     const {
         encryptionPassword,
         updateEncryptionPassword,
+        isLoading: isLoadingPassword,
     } = useEncryptionPassword();
 
     const [ualAccount] = useUALAccount();
@@ -43,27 +45,25 @@ export const EncryptionPasswordAlert = ({
     }
 
     const promptNewKey =
-        promptSetupEncryptionKey && !encryptionPassword.publicKey;
+        promptSetupEncryptionKey &&
+        !isLoadingPassword &&
+        !encryptionPassword.publicKey;
     if (promptNewKey) {
         return (
-            <Container>
-                <PromptNewKey
-                    updateEncryptionPassword={updateEncryptionPassword}
-                />
-            </Container>
+            <PromptNewKey updateEncryptionPassword={updateEncryptionPassword} />
         );
     }
 
     const warnKeyNotPresent =
-        encryptionPassword.publicKey && !encryptionPassword.privateKey;
+        !isLoadingPassword &&
+        encryptionPassword.publicKey &&
+        !encryptionPassword.privateKey;
     if (warnKeyNotPresent) {
         return (
-            <Container>
-                <NotPresentKeyWarning
-                    expectedPublicKey={encryptionPassword.publicKey!}
-                    updateEncryptionPassword={updateEncryptionPassword}
-                />
-            </Container>
+            <NotPresentKeyWarning
+                expectedPublicKey={encryptionPassword.publicKey!}
+                updateEncryptionPassword={updateEncryptionPassword}
+            />
         );
     }
 
@@ -77,20 +77,21 @@ interface PromptNewKeyProps {
 const PromptNewKey = ({ updateEncryptionPassword }: PromptNewKeyProps) => {
     const [showNewKeyModal, setShowNewKeyModal] = useState(false);
     return (
-        <div>
-            <Text>You have not setup your password yet.</Text>
+        <Container className="flex justify-center bg-yellow-500">
             <Button
-                type="neutral"
+                type="caution"
+                size="sm"
                 onClick={() => setShowNewKeyModal(!showNewKeyModal)}
             >
-                Setup Password
+                <BsExclamationTriangle className="mr-1 mb-px" />
+                Create Election Password
             </Button>
             <PromptNewKeyModal
                 updateEncryptionPassword={updateEncryptionPassword}
                 isOpen={showNewKeyModal}
                 close={() => setShowNewKeyModal(false)}
             />
-        </div>
+        </Container>
     );
 };
 
@@ -105,16 +106,14 @@ const NotPresentKeyWarning = ({
 }: NotPresentKeyWarningProps) => {
     const [showReenterKeyModal, setShowReenterKeyModal] = useState(false);
     return (
-        <div>
-            <Text type="danger">
-                Warning! Your election password is not present in the current
-                browser.
-            </Text>
+        <Container className="flex justify-center bg-yellow-500">
             <Button
-                type="neutral"
+                type="caution"
+                size="sm"
                 onClick={() => setShowReenterKeyModal(!showReenterKeyModal)}
             >
-                Re-enter Password
+                <BsExclamationTriangle className="mr-1 mb-px" />
+                Enter Election Password
             </Button>
             <PromptReenterKeyModal
                 updateEncryptionPassword={updateEncryptionPassword}
@@ -122,7 +121,7 @@ const NotPresentKeyWarning = ({
                 close={() => setShowReenterKeyModal(false)}
                 expectedPublicKey={expectedPublicKey}
             />
-        </div>
+        </Container>
     );
 };
 

--- a/packages/webapp/src/encryption/hooks.ts
+++ b/packages/webapp/src/encryption/hooks.ts
@@ -17,6 +17,7 @@ export const useEncryptionPassword = () => {
         encryptionPassword,
         setEncryptionPassword,
     ] = useState<EncryptionPassword>({});
+    const [isInitialized, setIsInitialized] = useState(false);
     const { data: currentMember, isLoading, error } = useCurrentMember();
 
     useEffect(() => {
@@ -29,8 +30,12 @@ export const useEncryptionPassword = () => {
                 publicKey,
                 privateKey,
             });
-        } else {
+            setIsInitialized(true);
+        } else if (Object.keys(encryptionPassword).length) {
+            // We needlessly update state causing extra hook updates if we set the password to {} when it's already {}.
+            // This prevents extra hook updates/renders and helps prevent the banner from flickering when loading.
             setEncryptionPassword({});
+            setIsInitialized(true);
         }
     }, [currentMember]);
 
@@ -45,7 +50,7 @@ export const useEncryptionPassword = () => {
     return {
         encryptionPassword,
         updateEncryptionPassword,
-        isLoading,
+        isLoading: isLoading || !isInitialized, // prevent flicker
         error,
     };
 };


### PR DESCRIPTION
## In this PR
1. The password prompt would flicker on load/refresh--even if the password was present for the signed-in user in the browser. I eliminated this by adding an `isInitialized` state flag to the hook. (But I'm interested, @sparkplug0025, if you see a better way of achieving this--I tried several.)
2. This moves the election password prompt to the layout as a full-width banner and restyles it.

![image](https://user-images.githubusercontent.com/7911424/128409606-013d362e-b405-430b-ac0d-de2672c65e77.png)
