### PR TITLE
New MemberChip per Delegation Level Layout

### DIFF
--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -48,7 +48,7 @@ export const getMyDelegation = async (
         let member = await getMemberWrapper(nextMemberAccount);
         if (!member)
             throw new Error(
-                `Member record not found for provided account[${nextMemberAccount}].`
+                `Member record not found for provided account [${nextMemberAccount}].`
             );
 
         // Fill the array from next available position up to member.election_rank with member,

--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -98,6 +98,7 @@ const getDelegateLevelDescription = (
     const { data: chiefDelegates } = useChiefDelegates();
 
     const prefix = "D" + (level - 1);
+    if (level === 1) return "Member";
     if (headDelegate === memberAccount) return prefix + " - Head Chief";
     if (chiefDelegates?.includes(memberAccount))
         return prefix + " - Chief Delegate";

--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -5,7 +5,6 @@ import {
     ipfsUrl,
     openInNewTab,
     useChiefDelegates,
-    useElectionState,
     useHeadDelegate,
 } from "_app";
 import { ROUTES } from "_app/config";

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -7,9 +7,9 @@ export const fixtureEdenMembers: EdenMember[] = [
         account: "alice.edev",
         nft_template_id: 147800,
         status: MemberStatus.ActiveMember,
-        election_participation_status: ElectionParticipationStatus.NoDonation,
+        election_participation_status: ElectionParticipationStatus.NoDonation, // See ElectionParticipationStatus for enum values; NoDonation is kinda the default if other special cases don't apply
         election_rank: 5,
-        representative: "alice.edev",
+        representative: "alice.edev", // "parent" field
     },
     {
         name: "Egeon The Great",
@@ -43,18 +43,18 @@ export const fixtureEdenMembers: EdenMember[] = [
         account: "edenmember12",
         nft_template_id: 147806,
         status: MemberStatus.ActiveMember,
-        election_participation_status: ElectionParticipationStatus.NoDonation, // See ElectionParticipationStatus for enum values; NoDonation is kinda the default if other special cases don't apply
+        election_participation_status: ElectionParticipationStatus.NoDonation,
         election_rank: 2,
-        representative: "", // "parent" field
+        representative: "",
     },
     {
         name: "Eden Member 13",
         account: "edenmember13",
         nft_template_id: 147807,
         status: MemberStatus.ActiveMember,
-        election_participation_status: ElectionParticipationStatus.NoDonation, // See ElectionParticipationStatus for enum values; NoDonation is kinda the default if other special cases don't apply
+        election_participation_status: ElectionParticipationStatus.NoDonation,
         election_rank: 1,
-        representative: "edenmember14", // "parent" field
+        representative: "edenmember14",
     },
     {
         name: "Eden Member 14",

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -9,6 +9,8 @@ export const fixtureEdenMembers: EdenMember[] = [
         status: MemberStatus.ActiveMember,
         election_participation_status: ElectionParticipationStatus.NoDonation, // See ElectionParticipationStatus for enum values; NoDonation is kinda the default if other special cases don't apply
         election_rank: 5,
+        // representative field will be same as account field for Head Chief
+        // see isValidDelegate() for other special values and their meaning
         representative: "alice.edev", // "parent" field
     },
     {

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -169,13 +169,9 @@ const Chiefs = () => {
                 <Text>Chief Delegates</Text>
             </Container>
             {chiefsAsMembers.map((delegate) => {
-                if (
-                    !delegate // ||
-                    // delegate.account === electionState.lead_representative
-                )
-                    return null;
+                if (!delegate) return null;
                 return (
-                    <div className="-mt-px" key={`chiefs-${delegate.account}`}>
+                    <div key={`chiefs-${delegate.account}`}>
                         <DelegateChip
                             member={members.find(
                                 (d) => d.account === delegate.account

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -84,7 +84,7 @@ const Delegates = ({
     members,
     myDelegation,
 }: {
-    members?: MemberData[];
+    members: MemberData[];
     myDelegation: EdenMember[];
 }) => {
     const { data: membersStats, isLoading } = useMemberStats();
@@ -108,7 +108,7 @@ const Delegates = ({
                         key={`my-delegation-${index}-${delegate.account}`}
                     >
                         <DelegateChip
-                            member={members!.find(
+                            member={members.find(
                                 (d) => d.account === delegate.account
                             )}
                             level={index + 1}

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -64,7 +64,7 @@ export const DelegatesPage = (props: Props) => {
                 <div>not an Eden Member</div>
             </FluidLayout>
         );
-    if (!myDelegation || (myDelegation?.length > 0 && !members))
+    if (!myDelegation || !members || (myDelegation?.length > 0 && !members))
         return (
             <FluidLayout>
                 <div>fetching your Delegation and members...</div>
@@ -111,31 +111,42 @@ const Delegates = ({
         ? myDelegation[myDelegation.length - 1]
         : loggedInMember;
 
+    console.info("members:");
+    console.info(members);
+
+    const heightOfDelegationWithoutChiefs = membersStats.ranks.length - 2;
+    const diff = heightOfDelegationWithoutChiefs - myDelegation.length;
+    const numLevelsWithNoRepresentation = diff > 0 ? diff : 0;
+    console.info("numLevelsWithNoRepresentation:");
+    console.info(numLevelsWithNoRepresentation);
+
     return (
         <>
-            {myDelegation.map((delegate, index) => (
-                <div
-                    className="-mt-px"
-                    key={`my-delegation-${members![index].account}`}
-                >
-                    <DelegateChip
-                        member={members!.find(
-                            (d) => d.account === delegate.account
-                        )}
-                        level={delegate.election_rank}
-                    />
-                    <MyDelegationArrow />
-                </div>
-            ))}
-            {isGapInRepresentation(
-                highestRankedMemberInDelegation,
-                membersStats
-            ) && (
-                <div className="-mt-px">
+            {myDelegation.map((delegate, index) => {
+                console.info(`index[${index}`);
+                console.info("delegate:");
+                console.info(delegate);
+                return (
+                    <div
+                        className="-mt-px"
+                        key={`my-delegation-${members![index].account}`}
+                    >
+                        <DelegateChip
+                            member={members!.find(
+                                (d) => d.account === delegate.account
+                            )}
+                            level={delegate.election_rank}
+                        />
+                        <MyDelegationArrow />
+                    </div>
+                );
+            })}
+            {[...Array(numLevelsWithNoRepresentation)].map((v, idx) => (
+                <div className="-mt-px" key={idx}>
                     <DelegateChip />
                     <MyDelegationArrow />
                 </div>
-            )}
+            ))}
             <Chiefs />
         </>
     );

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -16,24 +16,11 @@ import {
     useUALAccount,
 } from "_app";
 import { DelegateChip } from "elections";
-import { EdenMember, MemberData, MemberStats } from "members/interfaces";
-import { isValidDelegate } from "delegates/api";
+import { EdenMember, MemberData } from "members/interfaces";
 
 interface Props {
     delegatesPage: number;
 }
-
-const isDelegateAChief = (delegateRank: number, membersStats: MemberStats) =>
-    delegateRank > membersStats.ranks.length - 2;
-
-const isGapInRepresentation = (
-    highestRankedMemberInDelegation: EdenMember,
-    membersStats: MemberStats
-) =>
-    !isDelegateAChief(
-        highestRankedMemberInDelegation.election_rank + 1,
-        membersStats
-    ) && !isValidDelegate(highestRankedMemberInDelegation.representative);
 
 export const DelegatesPage = (props: Props) => {
     const [activeUser] = useUALAccount();
@@ -107,40 +94,28 @@ const Delegates = ({
     if (!loggedInMember || !membersStats)
         return <div>Error fetching member data...</div>;
 
-    const highestRankedMemberInDelegation = myDelegation.length
-        ? myDelegation[myDelegation.length - 1]
-        : loggedInMember;
-
-    console.info("members:");
-    console.info(members);
-
     const heightOfDelegationWithoutChiefs = membersStats.ranks.length - 2;
     const diff = heightOfDelegationWithoutChiefs - myDelegation.length;
     const numLevelsWithNoRepresentation = diff > 0 ? diff : 0;
-    console.info("numLevelsWithNoRepresentation:");
-    console.info(numLevelsWithNoRepresentation);
 
     return (
         <>
-            {myDelegation.map((delegate, index) => {
-                console.info(`index[${index}`);
-                console.info("delegate:");
-                console.info(delegate);
-                return (
+            {myDelegation
+                .slice(0, membersStats.ranks.length - 2)
+                .map((delegate, index) => (
                     <div
                         className="-mt-px"
-                        key={`my-delegation-${members![index].account}`}
+                        key={`my-delegation-${index}-${delegate.account}`}
                     >
                         <DelegateChip
                             member={members!.find(
                                 (d) => d.account === delegate.account
                             )}
-                            level={delegate.election_rank}
+                            level={index + 1}
                         />
                         <MyDelegationArrow />
                     </div>
-                );
-            })}
+                ))}
             {[...Array(numLevelsWithNoRepresentation)].map((v, idx) => (
                 <div className="-mt-px" key={idx}>
                     <DelegateChip />
@@ -195,8 +170,8 @@ const Chiefs = () => {
             </Container>
             {chiefsAsMembers.map((delegate) => {
                 if (
-                    !delegate ||
-                    delegate.account === electionState.lead_representative
+                    !delegate // ||
+                    // delegate.account === electionState.lead_representative
                 )
                     return null;
                 return (
@@ -205,7 +180,7 @@ const Chiefs = () => {
                             member={members.find(
                                 (d) => d.account === delegate.account
                             )}
-                            level={delegate.election_rank}
+                            level={membersStats.ranks.length - 1}
                         />
                     </div>
                 );


### PR DESCRIPTION
This switches us from the truncated view of My Delegation to the one-delegate-at-each-level view.

Still to do (once the UX is fully ironed out)
 - add different badges per delegate level
 - likely alter the per-level header / level description
 - Finalize/nice-ify the error handling/loading states

Scenarios
1: **Gap in Delegation** edenmember11 has direct rep, but that rep failed to form consensus in Round 2, leaving a gap between them and the Chiefs
![image](https://user-images.githubusercontent.com/80084763/128415091-ad02b1c4-2bfc-4b5c-b123-c233071b9178.png)

2: **Vote for a Chief / Same delegate in many levels** edenmember22 voted in Round 1 for the person (Alice) who eventually became the Head Chief.
![image](https://user-images.githubusercontent.com/80084763/128415286-f993088d-e308-4125-ab89-047275494917.png)

3: **Logged-in user has no direct delegate** edenmember23 failed to come to consensus in Round 1
![image](https://user-images.githubusercontent.com/80084763/128416019-645be4f2-5e04-4da5-873c-267775103862.png)

4: **No Gap in Delegation / Different delegate at every level** edenmember21 voted for a chain of succession that included a distinct delegate at each level
![image](https://user-images.githubusercontent.com/80084763/128415522-714ca354-04f3-4122-b7bd-25f6920cbc66.png)

5: **No Gap in Delegation / Same delegate at multiple levels** edenmember15 voted for egeon, then egeon advanced a level (leaving this delegation showing a repeat in D1 and D2), then voted for Alice
![image](https://user-images.githubusercontent.com/80084763/128415633-2bacfb2c-a351-405d-9ce3-e675d70d86d3.png)
