### PR TITLE
Add Encryption password detection to Participation

### DIFF
--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -210,27 +210,6 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
         await onSubmit(setEncryptionPasswordTrx);
     };
 
-    const renderStep = () => {
-        switch (step) {
-            case ParticipationStep.ConfirmParticipation:
-                return (
-                    <ConfirmParticipationStep
-                        onSubmit={submitParticipationConfirmation}
-                        isLoading={isLoading}
-                        onCancel={close}
-                    />
-                );
-            case ParticipationStep.ConfirmPassword:
-                return (
-                    <ConfirmPasswordStep
-                        onSubmit={submitPasswordConfirmation}
-                        isLoading={isLoading}
-                        onCancel={close}
-                    />
-                );
-        }
-    };
-
     return (
         <Modal
             isOpen={isOpen}
@@ -241,7 +220,20 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
             shouldCloseOnOverlayClick={!isLoading}
             shouldCloseOnEsc={!isLoading}
         >
-            {renderStep()}
+            {step === ParticipationStep.ConfirmParticipation && (
+                <ConfirmParticipationStep
+                    onSubmit={submitParticipationConfirmation}
+                    isLoading={isLoading}
+                    onCancel={close}
+                />
+            )}
+            {step === ParticipationStep.ConfirmPassword && (
+                <ConfirmPasswordStep
+                    onSubmit={submitPasswordConfirmation}
+                    isLoading={isLoading}
+                    onCancel={close}
+                />
+            )}
         </Modal>
     );
 };

--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 
 import {
     Button,
@@ -18,6 +18,12 @@ import {
 import { extractElectionDates } from "../../utils";
 import { setElectionParticipation } from "../../transactions";
 import { useQueryClient } from "react-query";
+import {
+    setEncryptionPublicKeyTransaction,
+    useEncryptionPassword,
+} from "encryption";
+import { NewPasswordForm } from "encryption/components/new-password-form";
+import { ReenterPasswordForm } from "encryption/components/reenter-password-form";
 
 export const ParticipationCard = () => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
@@ -124,14 +130,30 @@ interface ModalProps {
     close: () => void;
 }
 
+enum ParticipationStep {
+    ConfirmParticipation,
+    ConfirmPassword,
+}
+
+interface SetEncryptionPasswordAction {
+    privateKey: string;
+    publicKey: string;
+    trx: any;
+}
+
 const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [ualAccount] = useUALAccount();
     const queryClient = useQueryClient();
+    const [step, setStep] = useState(ParticipationStep.ConfirmParticipation);
+    const {
+        encryptionPassword,
+        updateEncryptionPassword,
+    } = useEncryptionPassword();
 
-    const onSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-
+    const onSubmit = async (
+        setEncryptionPasswordAction?: SetEncryptionPasswordAction
+    ) => {
         setIsLoading(true);
 
         try {
@@ -142,10 +164,24 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
             );
             console.info("signing trx", transaction);
 
+            if (setEncryptionPasswordAction) {
+                transaction.actions = [
+                    ...transaction.actions,
+                    ...setEncryptionPasswordAction.trx.actions,
+                ];
+            }
+
             const signedTrx = await ualAccount.signTransaction(transaction, {
                 broadcast: true,
             });
             console.info("electopt trx", signedTrx);
+
+            if (setEncryptionPasswordAction) {
+                updateEncryptionPassword(
+                    setEncryptionPasswordAction.publicKey,
+                    setEncryptionPasswordAction.privateKey
+                );
+            }
 
             // invalidate current member query to update participating status
             queryClient.invalidateQueries(
@@ -161,6 +197,41 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
         setIsLoading(false);
     };
 
+    const submitParticipationConfirmation = () => {
+        if (!encryptionPassword.privateKey) {
+            setStep(ParticipationStep.ConfirmPassword);
+        } else {
+            onSubmit();
+        }
+    };
+
+    const submitPasswordConfirmation = async (
+        setEncryptionPasswordTrx?: any
+    ) => {
+        await onSubmit(setEncryptionPasswordTrx);
+    };
+
+    const renderStep = () => {
+        switch (step) {
+            case ParticipationStep.ConfirmParticipation:
+                return (
+                    <ConfirmParticipationStep
+                        onSubmit={submitParticipationConfirmation}
+                        isLoading={isLoading}
+                        onCancel={close}
+                    />
+                );
+            case ParticipationStep.ConfirmPassword:
+                return (
+                    <ConfirmPasswordStep
+                        onSubmit={submitPasswordConfirmation}
+                        isLoading={isLoading}
+                        onCancel={close}
+                    />
+                );
+        }
+    };
+
     return (
         <Modal
             isOpen={isOpen}
@@ -171,43 +242,116 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
             shouldCloseOnOverlayClick={!isLoading}
             shouldCloseOnEsc={!isLoading}
         >
-            <form onSubmit={onSubmit}>
-                <div className="space-y-4">
-                    <Text>
-                        You are committing to participate in the upcoming
-                        election. Not showing up could impact your standing and
-                        reputation in the community. If for some reason you
-                        cannot participate in the election, please update your
-                        status more than 24 hours from the election.
-                    </Text>
-                    <div className="p-3 border rounded">
-                        <Form.Checkbox
-                            id="confirm-checkbox"
-                            label="I agree to keep my participation status up to date."
-                            disabled={isLoading}
-                            required
-                        />
-                    </div>
-                    <div className="flex space-x-3">
-                        <Button
-                            type="neutral"
-                            onClick={close}
-                            disabled={isLoading}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            isSubmit
-                            isLoading={isLoading}
-                            disabled={isLoading}
-                        >
-                            {isLoading ? "Submitting..." : "Confirm"}
-                        </Button>
-                    </div>
-                </div>
-            </form>
+            {renderStep()}
         </Modal>
     );
+};
+
+interface ConfirmParticipationStepProps {
+    onSubmit: () => void;
+    isLoading?: boolean;
+    onCancel: () => void;
+}
+
+const ConfirmParticipationStep = ({
+    onSubmit,
+    isLoading,
+    onCancel,
+}: ConfirmParticipationStepProps) => {
+    const doSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        onSubmit();
+    };
+
+    return (
+        <form onSubmit={doSubmit}>
+            <div className="space-y-4">
+                <Text>
+                    You are committing to participate in the upcoming election.
+                    Not showing up could impact your standing and reputation in
+                    the community. If for some reason you cannot participate in
+                    the election, please update your status more than 24 hours
+                    from the election.
+                </Text>
+                <div className="p-3 border rounded">
+                    <Form.Checkbox
+                        id="confirm-checkbox"
+                        label="I agree to keep my participation status up to date."
+                        disabled={isLoading}
+                        required
+                    />
+                </div>
+                <div className="flex space-x-3">
+                    <Button
+                        type="neutral"
+                        onClick={onCancel}
+                        disabled={isLoading}
+                    >
+                        Cancel
+                    </Button>
+                    <Button isSubmit isLoading={isLoading} disabled={isLoading}>
+                        {isLoading ? "Submitting..." : "Confirm"}
+                    </Button>
+                </div>
+            </div>
+        </form>
+    );
+};
+
+interface ConfirmPasswordStepProps {
+    onSubmit: (
+        setEncryptionPasswordAction?: SetEncryptionPasswordAction
+    ) => void;
+    isLoading?: boolean;
+    onCancel: () => void;
+}
+
+const ConfirmPasswordStep = ({
+    onSubmit,
+    isLoading,
+    onCancel,
+}: ConfirmPasswordStepProps) => {
+    const [ualAccount] = useUALAccount();
+    const {
+        encryptionPassword,
+        updateEncryptionPassword,
+    } = useEncryptionPassword();
+
+    if (encryptionPassword.publicKey) {
+        // public key present, user needs to re-enter password
+        const doSubmit = async (
+            publicKey: string,
+            privateKey: string
+        ): Promise<void> => {
+            await onSubmit({ trx: { actions: [] }, publicKey, privateKey });
+        };
+        return (
+            <ReenterPasswordForm
+                expectedPublicKey={encryptionPassword.publicKey}
+                onSubmit={doSubmit}
+                onCancel={onCancel}
+            />
+        );
+    } else {
+        const doSubmit = async (
+            publicKey: string,
+            privateKey: string
+        ): Promise<void> => {
+            const authorizerAccount = ualAccount.accountName;
+            const trx = setEncryptionPublicKeyTransaction(
+                authorizerAccount,
+                publicKey
+            );
+            await onSubmit({ trx, publicKey, privateKey });
+        };
+        return (
+            <NewPasswordForm
+                isLoading={isLoading}
+                onSubmit={doSubmit}
+                onCancel={onCancel}
+            />
+        );
+    }
 };
 
 const CancelParticipationModal = ({ isOpen, close }: ModalProps) => {

--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -22,8 +22,7 @@ import {
     setEncryptionPublicKeyTransaction,
     useEncryptionPassword,
 } from "encryption";
-import { NewPasswordForm } from "encryption/components/new-password-form";
-import { ReenterPasswordForm } from "encryption/components/reenter-password-form";
+import { NewPasswordForm, ReenterPasswordForm } from "encryption";
 
 export const ParticipationCard = () => {
     const [ualAccount, _, ualShowModal] = useUALAccount();

--- a/packages/webapp/src/encryption/components/encryption-password-alert.tsx
+++ b/packages/webapp/src/encryption/components/encryption-password-alert.tsx
@@ -1,24 +1,18 @@
-import { PrivateKey } from "eosjs/dist/PrivateKey";
 import { useState } from "react";
 import { BsExclamationTriangle } from "react-icons/bs";
 
 import {
     Button,
     Container,
-    Form,
     MemberStatus,
     Modal,
     onError,
-    Text,
     useCurrentMember,
-    useFormFields,
     useUALAccount,
 } from "_app";
-import { generateEncryptionKey } from "_app/eos/secret-publisher";
-import { setEncryptionPublicKeyTransaction } from "encryption/transactions";
 
+import { setEncryptionPublicKeyTransaction } from "../transactions";
 import { UpdateEncryptionPassword, useEncryptionPassword } from "../hooks";
-import { useEffect } from "react";
 import { NewPasswordForm } from "./new-password-form";
 import { ReenterPasswordForm } from "./reenter-password-form";
 

--- a/packages/webapp/src/encryption/components/encryption-password-alert.tsx
+++ b/packages/webapp/src/encryption/components/encryption-password-alert.tsx
@@ -19,6 +19,8 @@ import { setEncryptionPublicKeyTransaction } from "encryption/transactions";
 
 import { UpdateEncryptionPassword, useEncryptionPassword } from "../hooks";
 import { useEffect } from "react";
+import { NewPasswordForm } from "./new-password-form";
+import { ReenterPasswordForm } from "./reenter-password-form";
 
 interface Props {
     promptSetupEncryptionKey?: boolean;
@@ -139,46 +141,10 @@ const PromptNewKeyModal = ({
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [ualAccount] = useUALAccount();
 
-    const [copyText, setCopyText] = useState("Copy");
-    const [fields, setFields] = useFormFields({
-        password: generateEncryptionKey().privateKey.toLegacyString(),
-        passwordConfirmation: "",
-    });
-    const onChangeFields = (e: React.ChangeEvent<HTMLInputElement>) =>
-        setFields(e);
-
-    const resetForm = () => {
-        setCopyText("Copy");
-        setFields({
-            target: {
-                id: "password",
-                value: generateEncryptionKey().privateKey.toLegacyString(),
-            },
-        });
-        setFields({
-            target: {
-                id: "passwordConfirmation",
-                value: "",
-            },
-        });
-    };
-    useEffect(resetForm, [isOpen]);
-
-    const onSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-
-        if (fields.password !== fields.passwordConfirmation) {
-            onError(new Error("Password confirmation does not match."));
-            return;
-        }
-
+    const onSubmit = async (publicKey: string, privateKey: string) => {
         setIsLoading(true);
 
         try {
-            const publicKey = PrivateKey.fromString(
-                fields.password
-            ).getPublicKey();
-
             const authorizerAccount = ualAccount.accountName;
             const transaction = setEncryptionPublicKeyTransaction(
                 authorizerAccount,
@@ -191,11 +157,7 @@ const PromptNewKeyModal = ({
             });
             console.info("set encryption public key trx", signedTrx);
 
-            updateEncryptionPassword(
-                publicKey.toLegacyString(),
-                fields.password
-            );
-
+            updateEncryptionPassword(publicKey, privateKey);
             close();
         } catch (error) {
             console.error(error);
@@ -203,11 +165,6 @@ const PromptNewKeyModal = ({
         }
 
         setIsLoading(false);
-    };
-
-    const copyPassword = () => {
-        navigator.clipboard.writeText(fields.password);
-        setCopyText("Copied!");
     };
 
     return (
@@ -220,61 +177,11 @@ const PromptNewKeyModal = ({
             shouldCloseOnOverlayClick={!isLoading}
             shouldCloseOnEsc={!isLoading}
         >
-            <div className="space-y-4">
-                <Text>
-                    It looks like you don’t have a password set to participate
-                    in the election. Please copy your password and confirm it
-                    here.
-                </Text>
-                <Text>Copy Password</Text>
-                <form onSubmit={onSubmit} className="space-y-3">
-                    <Form.LabeledSet
-                        label="Your Election Password"
-                        htmlFor="password"
-                        className="col-span-6 sm:col-span-3"
-                    >
-                        <Form.Input
-                            id="password"
-                            type="text"
-                            disabled
-                            required
-                            value={fields.password}
-                            onChange={onChangeFields}
-                        />
-                        <Button onClick={copyPassword}>{copyText}</Button>
-                    </Form.LabeledSet>
-                    <Text>Please paste your password below.</Text>
-                    <Form.LabeledSet
-                        label="Confirm Your Election Password"
-                        htmlFor="passwordConfirmation"
-                        className="col-span-6 sm:col-span-3"
-                    >
-                        <Form.Input
-                            id="passwordConfirmation"
-                            type="text"
-                            required
-                            value={fields.passwordConfirmation}
-                            onChange={onChangeFields}
-                        />
-                    </Form.LabeledSet>
-                    <div className="flex space-x-3">
-                        <Button
-                            type="neutral"
-                            onClick={close}
-                            disabled={isLoading}
-                        >
-                            Cancel
-                        </Button>
-                        <Button
-                            isSubmit
-                            isLoading={isLoading}
-                            disabled={!fields.passwordConfirmation || isLoading}
-                        >
-                            {isLoading ? "Submitting..." : "Submit"}
-                        </Button>
-                    </div>
-                </form>
-            </div>
+            <NewPasswordForm
+                isLoading={isLoading}
+                onSubmit={onSubmit}
+                onCancel={close}
+            />
         </Modal>
     );
 };
@@ -289,47 +196,10 @@ const PromptReenterKeyModal = ({
     expectedPublicKey,
     updateEncryptionPassword,
 }: PromptReenterKeyModalProps) => {
-    const [fields, setFields] = useFormFields({
-        password: "",
-    });
-    const onChangeFields = (e: React.ChangeEvent<HTMLInputElement>) =>
-        setFields(e);
-
-    const resetForm = () => {
-        setFields({
-            target: {
-                id: "password",
-                value: "",
-            },
-        });
-    };
-    useEffect(resetForm, [isOpen]);
-
-    const onSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-
+    const onSubmit = async (publicKey: string, privateKey: string) => {
         try {
-            const publicKey = PrivateKey.fromString(
-                fields.password
-            ).getPublicKey();
-
-            if (publicKey.toLegacyString() !== expectedPublicKey) {
-                onError(new Error("The entered password is not correct"));
-                return;
-            }
-
-            updateEncryptionPassword(
-                publicKey.toLegacyString(),
-                fields.password
-            );
+            updateEncryptionPassword(publicKey, privateKey);
             close();
-
-            setFields({
-                target: {
-                    id: "password",
-                    value: "",
-                },
-            });
         } catch (error) {
             console.error(error);
             onError(error);
@@ -346,32 +216,11 @@ const PromptReenterKeyModal = ({
             shouldCloseOnOverlayClick
             shouldCloseOnEsc
         >
-            <div className="space-y-4">
-                <Text>Please enter your Eden Election Password below.</Text>
-                <form onSubmit={onSubmit} className="space-y-3">
-                    <Form.LabeledSet
-                        label="Your Election Password"
-                        htmlFor="password"
-                        className="col-span-6 sm:col-span-3"
-                    >
-                        <Form.Input
-                            id="password"
-                            type="text"
-                            required
-                            value={fields.password}
-                            onChange={onChangeFields}
-                        />
-                    </Form.LabeledSet>
-                    <div className="flex space-x-3">
-                        <Button type="neutral" onClick={close}>
-                            Cancel
-                        </Button>
-                        <Button isSubmit disabled={!fields.password}>
-                            Submit
-                        </Button>
-                    </div>
-                </form>
-            </div>
+            <ReenterPasswordForm
+                expectedPublicKey={expectedPublicKey}
+                onSubmit={onSubmit}
+                onCancel={close}
+            />
         </Modal>
     );
 };

--- a/packages/webapp/src/encryption/components/index.tsx
+++ b/packages/webapp/src/encryption/components/index.tsx
@@ -1,1 +1,3 @@
 export * from "./encryption-password-alert";
+export * from "./new-password-form";
+export * from "./reenter-password-form";

--- a/packages/webapp/src/encryption/components/new-password-form.tsx
+++ b/packages/webapp/src/encryption/components/new-password-form.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { PrivateKey } from "eosjs/dist/eosjs-key-conversions";
+
+import {
+    Button,
+    Form,
+    generateEncryptionKey,
+    onError,
+    Text,
+    useFormFields,
+} from "_app";
+
+interface Props {
+    isLoading?: boolean;
+    onSubmit: (publicKey: string, privateKey: string) => Promise<void>;
+    onCancel: () => void;
+}
+
+export const NewPasswordForm = ({ isLoading, onSubmit, onCancel }: Props) => {
+    const [copyText, setCopyText] = useState("Copy");
+    const [fields, setFields] = useFormFields({
+        password: generateEncryptionKey().privateKey.toLegacyString(),
+        passwordConfirmation: "",
+    });
+    const onChangeFields = (e: React.ChangeEvent<HTMLInputElement>) =>
+        setFields(e);
+
+    const doSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (fields.password !== fields.passwordConfirmation) {
+            onError(new Error("Password confirmation does not match."));
+            return;
+        }
+
+        try {
+            const publicKey = PrivateKey.fromString(
+                fields.password
+            ).getPublicKey();
+            await onSubmit(publicKey.toLegacyString(), fields.password);
+        } catch (error) {
+            console.error(error);
+            onError(error);
+        }
+    };
+
+    const copyPassword = () => {
+        navigator.clipboard.writeText(fields.password);
+        setCopyText("Copied!");
+    };
+
+    return (
+        <div className="space-y-4">
+            <Text>
+                It looks like you don’t have a password set to participate in
+                the election. Please copy your password and confirm it here.
+            </Text>
+            <Text>Copy Password</Text>
+            <form onSubmit={doSubmit} className="space-y-3">
+                <Form.LabeledSet
+                    label="Your Election Password"
+                    htmlFor="password"
+                    className="col-span-6 sm:col-span-3"
+                >
+                    <Form.Input
+                        id="password"
+                        type="text"
+                        disabled
+                        required
+                        value={fields.password}
+                        onChange={onChangeFields}
+                    />
+                    <Button onClick={copyPassword}>{copyText}</Button>
+                </Form.LabeledSet>
+                <Text>Please paste your password below.</Text>
+                <Form.LabeledSet
+                    label="Confirm Your Election Password"
+                    htmlFor="passwordConfirmation"
+                    className="col-span-6 sm:col-span-3"
+                >
+                    <Form.Input
+                        id="passwordConfirmation"
+                        type="text"
+                        required
+                        value={fields.passwordConfirmation}
+                        onChange={onChangeFields}
+                    />
+                </Form.LabeledSet>
+                <div className="flex space-x-3">
+                    <Button
+                        type="neutral"
+                        onClick={onCancel}
+                        disabled={isLoading}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        isSubmit
+                        isLoading={isLoading}
+                        disabled={!fields.passwordConfirmation || isLoading}
+                    >
+                        {isLoading ? "Submitting..." : "Submit"}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+};

--- a/packages/webapp/src/encryption/components/reenter-password-form.tsx
+++ b/packages/webapp/src/encryption/components/reenter-password-form.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { PrivateKey } from "eosjs/dist/eosjs-key-conversions";
 
 import { Button, Form, onError, Text, useFormFields } from "_app";

--- a/packages/webapp/src/encryption/components/reenter-password-form.tsx
+++ b/packages/webapp/src/encryption/components/reenter-password-form.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { PrivateKey } from "eosjs/dist/eosjs-key-conversions";
+
+import { Button, Form, onError, Text, useFormFields } from "_app";
+
+interface Props {
+    expectedPublicKey: string;
+    isLoading?: boolean;
+    onSubmit: (publicKey: string, privateKey: string) => Promise<void>;
+    onCancel: () => void;
+}
+
+export const ReenterPasswordForm = ({
+    expectedPublicKey,
+    isLoading,
+    onSubmit,
+    onCancel,
+}: Props) => {
+    const [fields, setFields] = useFormFields({
+        password: "",
+    });
+    const onChangeFields = (e: React.ChangeEvent<HTMLInputElement>) =>
+        setFields(e);
+
+    const doSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        try {
+            const publicKey = PrivateKey.fromString(
+                fields.password
+            ).getPublicKey();
+
+            if (publicKey.toLegacyString() !== expectedPublicKey) {
+                onError(new Error("The entered password is not correct"));
+                return;
+            }
+            await onSubmit(publicKey.toLegacyString(), fields.password);
+        } catch (error) {
+            console.error(error);
+            onError(error);
+        }
+    };
+
+    return (
+        <div className="space-y-4">
+            <Text>Please enter your Eden Election Password below.</Text>
+            <form onSubmit={doSubmit} className="space-y-3">
+                <Form.LabeledSet
+                    label="Your Election Password"
+                    htmlFor="password"
+                    className="col-span-6 sm:col-span-3"
+                >
+                    <Form.Input
+                        id="password"
+                        type="text"
+                        required
+                        value={fields.password}
+                        disabled={isLoading}
+                        onChange={onChangeFields}
+                    />
+                </Form.LabeledSet>
+                <div className="flex space-x-3">
+                    <Button type="neutral" onClick={onCancel}>
+                        Cancel
+                    </Button>
+                    <Button isSubmit disabled={!fields.password || isLoading}>
+                        Submit
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+};

--- a/packages/webapp/src/encryption/transactions.ts
+++ b/packages/webapp/src/encryption/transactions.ts
@@ -4,7 +4,7 @@ import { PublicKey } from "eosjs/dist/PublicKey";
 
 export const setEncryptionPublicKeyTransaction = (
     authorizerAccount: string,
-    encryptionPublicKey: PublicKey
+    encryptionPublicKey: string
 ) => ({
     actions: [
         {
@@ -18,7 +18,7 @@ export const setEncryptionPublicKeyTransaction = (
             ],
             data: {
                 account: authorizerAccount,
-                key: encryptionPublicKey.toLegacyString(),
+                key: encryptionPublicKey,
             },
         },
     ],


### PR DESCRIPTION
- Extracted the password forms from the encryption password alert
- Reused them in the participation when the password are required to confirm
- If the user has the encryption key in the browser the participation will NOT prompt for entering the key again