### PR TITLE
Ongoing Election Hookup - Real API!

### DIFF
--- a/packages/webapp/src/_app/eos/api.ts
+++ b/packages/webapp/src/_app/eos/api.ts
@@ -15,8 +15,10 @@ export const CONTRACT_VOTE_TABLE = "votes";
 export const CONTRACT_INDUCTION_TABLE = "induction";
 export const CONTRACT_ENDORSEMENT_TABLE = "endorsement";
 
+type TableResponseRow<T> = [string, T] | T;
+
 interface TableResponse<T> {
-    rows: [string, T][];
+    rows: TableResponseRow<T>[];
     more: boolean;
     next_key: string;
 }
@@ -58,13 +60,14 @@ export const getTableRows = async <T = any>(
     const rows = await getTableRawRows(table, options);
     // variants are structured as such: array[type: string, <object the variant contains>]
     // this line is reducing the data to just the data part
-    return rows.map((row) => row[1]);
+    if (rows?.[0].length) return rows.map((row) => row[1]);
+    return rows;
 };
 
 export const getTableRawRows = async <T = any>(
     table: string,
     options?: TableQueryOptions
-): Promise<[string, T][]> => {
+): Promise<TableResponseRow<T>[]> => {
     options = { ...TABLE_PARAM_DEFAULTS, ...options };
     const reverse = Boolean(options.lowerBound === "0" && options.upperBound);
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -79,7 +79,12 @@ export const queryParticipantsInCompletedRound = (
     electionRound?: number,
     member?: EdenMember
 ) => ({
-    queryKey: ["query_current_election", electionRound, member],
+    queryKey: [
+        "query_current_election",
+        electionRound,
+        member,
+        isStillParticipating,
+    ],
     queryFn: () => {
         if (typeof electionRound !== "number" || !member)
             throw new Error(
@@ -225,10 +230,8 @@ export const useHeadDelegate = () =>
         ...queryHeadDelegate,
     });
 
-export const useParticipantsInCompletedRound = (
-    electionRound?: number,
-    member?: EdenMember
-) => {
+export const useParticipantsInCompletedRound = (electionRound?: number) => {
+    const { data: member } = useCurrentMember();
     const { data: voteData } = useVoteDataRow(member?.account);
     console.info("voteData:", voteData);
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -258,6 +258,7 @@ export const useMemberGroupParticipants = (memberAccount?: string) => {
         ...queryMemberGroupParticipants(memberAccount, currentElection?.config),
         enabled: Boolean(memberAccount && currentElection?.config),
         refetchInterval: 10000,
+        refetchIntervalInBackground: true,
     });
 };
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -76,26 +76,17 @@ export const queryVoteData = (options: VoteDataQueryOptionsByGroup = {}) => ({
 });
 
 export const queryParticipantsInCompletedRound = (
-    isStillParticipating: boolean,
-    electionRound?: number,
-    member?: EdenMember
+    electionRound: number,
+    member?: EdenMember,
+    voteData?: VoteData
 ) => ({
-    queryKey: [
-        "query_current_election",
-        electionRound,
-        member,
-        isStillParticipating,
-    ],
+    queryKey: ["query_current_election", member, voteData, electionRound],
     queryFn: () => {
-        if (typeof electionRound !== "number" || !member)
+        if (!member)
             throw new Error(
-                "useParticipantsInCompletedRound() requires a value for 'memberAccount' and 'electionRound'"
+                "useParticipantsInCompletedRound() requires a value for 'memberAccount'"
             );
-        return getParticipantsInCompletedRound(
-            electionRound,
-            member,
-            isStillParticipating
-        );
+        return getParticipantsInCompletedRound(electionRound, member, voteData);
     },
 });
 
@@ -231,20 +222,13 @@ export const useHeadDelegate = () =>
         ...queryHeadDelegate,
     });
 
-export const useParticipantsInCompletedRound = (electionRound?: number) => {
+export const useParticipantsInMyCompletedRound = (electionRound: number) => {
     const { data: member } = useCurrentMember();
     const { data: voteData } = useVoteDataRow(member?.account);
-    console.info("voteData:", voteData);
 
-    const isStillParticipating = Boolean(voteData);
-    console.info(`isStillParticipating[${isStillParticipating}]`);
     return useQuery({
-        ...queryParticipantsInCompletedRound(
-            isStillParticipating,
-            electionRound,
-            member
-        ),
-        enabled: typeof electionRound === "number" && Boolean(member),
+        ...queryParticipantsInCompletedRound(electionRound, member, voteData),
+        enabled: Boolean(member),
     });
 };
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -75,6 +75,7 @@ export const queryVoteData = (options: VoteDataQueryOptionsByGroup = {}) => ({
 });
 
 export const queryParticipantsInCompletedRound = (
+    isStillParticipating: boolean,
     electionRound?: number,
     member?: EdenMember
 ) => ({
@@ -84,7 +85,11 @@ export const queryParticipantsInCompletedRound = (
             throw new Error(
                 "useParticipantsInCompletedRound() requires a value for 'memberAccount' and 'electionRound'"
             );
-        return getParticipantsInCompletedRound(electionRound, member);
+        return getParticipantsInCompletedRound(
+            electionRound,
+            member,
+            isStillParticipating
+        );
     },
 });
 
@@ -224,8 +229,17 @@ export const useParticipantsInCompletedRound = (
     electionRound?: number,
     member?: EdenMember
 ) => {
+    const { data: voteData } = useVoteDataRow(member?.account);
+    console.info("voteData:", voteData);
+
+    const isStillParticipating = Boolean(voteData);
+    console.info(`isStillParticipating[${isStillParticipating}]`);
     return useQuery({
-        ...queryParticipantsInCompletedRound(electionRound, member),
+        ...queryParticipantsInCompletedRound(
+            isStillParticipating,
+            electionRound,
+            member
+        ),
         enabled: typeof electionRound === "number" && Boolean(member),
     });
 };

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -233,6 +233,7 @@ export const useMemberGroupParticipants = (memberAccount?: string) => {
     return useQuery({
         ...queryMemberGroupParticipants(memberAccount, currentElection?.config),
         enabled: Boolean(memberAccount && currentElection?.config),
+        refetchInterval: 10000,
     });
 };
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -80,7 +80,7 @@ export const queryParticipantsInCompletedRound = (
 ) => ({
     queryKey: ["query_current_election", electionRound, member],
     queryFn: () => {
-        if (!electionRound || !member)
+        if (typeof electionRound !== "number" || !member)
             throw new Error(
                 "useParticipantsInCompletedRound() requires a value for 'memberAccount' and 'electionRound'"
             );
@@ -226,7 +226,7 @@ export const useParticipantsInCompletedRound = (
 ) => {
     return useQuery({
         ...queryParticipantsInCompletedRound(electionRound, member),
-        enabled: Boolean(electionRound && member),
+        enabled: typeof electionRound === "number" && Boolean(member),
     });
 };
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -9,6 +9,7 @@ import {
     getNewMembers,
     getMembersStats,
     VoteDataQueryOptionsByGroup,
+    MemberData,
 } from "members";
 import { getIsCommunityActive } from "_app/api";
 
@@ -33,7 +34,7 @@ import {
     getVoteData,
     getVoteDataRow,
 } from "elections/api/eden-contract";
-import { ActiveStateConfigType } from "elections/interfaces";
+import { ActiveStateConfigType, VoteData } from "elections/interfaces";
 
 export const queryHeadDelegate = {
     queryKey: "query_head_delegate",
@@ -287,3 +288,38 @@ export const useVoteData = (
         ...queryVoteData(voteQueryConfig),
         ...queryOptions,
     });
+
+export const useMemberDataFromEdenMembers = (
+    members?: EdenMember[],
+    queryOptions: any = {}
+) => {
+    const nftTemplateIds = members?.map((em) => em.nft_template_id);
+
+    let enabled = Boolean(nftTemplateIds?.length);
+    if ("enabled" in queryOptions) {
+        enabled = enabled && queryOptions.enabled;
+    }
+
+    return useQuery<MemberData[], Error>({
+        ...queryMembers(1, nftTemplateIds?.length, nftTemplateIds),
+        staleTime: Infinity,
+        ...queryOptions,
+        enabled,
+    });
+};
+
+export const useMemberDataFromVoteData = (voteData?: VoteData[]) => {
+    const responses = useMemberListByAccountNames(
+        voteData?.map((participant) => participant.member) ?? []
+    );
+    const isFetchError = responses.some((res) => res.isError);
+    const areQueriesComplete = responses.every((res) => res.isSuccess);
+
+    const edenMembers = responses
+        .filter((res) => Boolean(res?.data?.nft_template_id))
+        .map((res) => res.data as EdenMember);
+
+    return useMemberDataFromEdenMembers(edenMembers, {
+        enabled: !isFetchError && areQueriesComplete,
+    });
+};

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -8,6 +8,7 @@ import {
     getTreasuryStats,
     getNewMembers,
     getMembersStats,
+    VoteDataQueryOptionsByGroup,
 } from "members";
 import { getIsCommunityActive } from "_app/api";
 
@@ -29,6 +30,7 @@ import {
     getElectionState,
     getMemberGroupParticipants,
     getParticipantsInCompletedRound,
+    getVoteData,
     getVoteDataRow,
 } from "elections/api/eden-contract";
 import { ActiveStateConfigType } from "elections/interfaces";
@@ -65,6 +67,11 @@ export const queryVoteDataRow = (account?: string) => ({
             );
         return getVoteDataRow({ fieldName: "member", fieldValue: account });
     },
+});
+
+export const queryVoteData = (options: VoteDataQueryOptionsByGroup = {}) => ({
+    queryKey: ["query_vote_data"],
+    queryFn: () => getVoteData(options),
 });
 
 export const queryParticipantsInCompletedRound = (
@@ -253,3 +260,12 @@ export const useVoteDataRow = (account?: string) => {
         enabled: Boolean(account),
     });
 };
+
+export const useVoteData = (
+    voteQueryConfig: VoteDataQueryOptionsByGroup,
+    queryOptions = {}
+) =>
+    useQuery({
+        ...queryVoteData(voteQueryConfig),
+        ...queryOptions,
+    });

--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -49,7 +49,11 @@ export const getMyDelegation = async (
 
         // Fill the array from next available position up to member.election_rank with member,
         // in case this delegate got voted up through multiple levels
-        for (let idx = myDelegates.length; idx < member?.election_rank; idx++) {
+        for (
+            let idx = myDelegates.length;
+            idx <= member?.election_rank;
+            idx++
+        ) {
             myDelegates.push(member);
         }
         isHeadChief = member.account === member.representative;

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -98,11 +98,13 @@ export const getMemberGroupParticipants = async (
         numGroups
     );
 
+    const GET_VOTE_DATA_ROWS_LIMIT = 20;
+
     // get all members in this member's group
     const rows = await getVoteDataRows({
         lowerBound,
         upperBound,
-        limit: upperBound - lowerBound,
+        limit: GET_VOTE_DATA_ROWS_LIMIT,
         key_type: "i64",
         index_position: 2,
     });

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -21,7 +21,6 @@ import {
     getTableRawRows,
     getTableRows,
     isValidDelegate,
-    useVoteDataRow,
 } from "_app";
 import {
     fixtureCurrentElection,

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -86,6 +86,7 @@ export const getMemberGroupParticipants = async (
     // get member index
     const memberVoteData = await getVoteDataRow({
         fieldValue: memberAccount,
+        fieldName: "member",
     });
     if (!memberVoteData) return [];
 
@@ -101,6 +102,9 @@ export const getMemberGroupParticipants = async (
     const rows = await getVoteDataRows({
         lowerBound,
         upperBound,
+        limit: upperBound - lowerBound,
+        key_type: "i64",
+        index_position: 2,
     });
 
     if (!rows || !rows.length) {
@@ -138,16 +142,10 @@ const getVoteDataRows = async (
 
     // TODO: see what real data looks like and real use-cases and see if we need the electionState flag;
     // If not, switch this back to getTableRows()
-    const rawRows = await getTableRawRows<VoteData>(CONTRACT_VOTE_TABLE, opts);
-    // const electionState = rawRows[0][0];
+    const rawRows = await getTableRawRows(CONTRACT_VOTE_TABLE, opts);
 
-    const rows = rawRows.map((row) => row[1]);
-
-    if (!rows.length) {
-        return undefined;
-    }
-
-    return rows;
+    if (rawRows?.[0].length) return rawRows.map((row) => row[1]);
+    return rawRows;
 };
 
 export const getVoteData = getVoteDataRows;

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -176,6 +176,7 @@ export const getParticipantsInCompletedRound = async (
     member: EdenMember,
     isStillParticipating: boolean
 ) => {
+    // TODO: For non-winner user, grab winner from their rep field and add it in below
     console.info(
         `getParticipantsInCompletedRound(isStillParticipating[${isStillParticipating}]).top`
     );

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -174,7 +174,10 @@ const getCommonDelegateAccountForGroupWithThisMember = (
         );
     }
 
-    return isValidDelegate(commonDelegate) ? commonDelegate : "";
+    if (isValidDelegate(commonDelegate)) return commonDelegate;
+    throw new Error(
+        "Could not find a valid common delegate. Maybe your group did not come to consensus?"
+    );
 };
 
 export const getParticipantsInCompletedRound = async (
@@ -187,7 +190,6 @@ export const getParticipantsInCompletedRound = async (
         member,
         voteData
     );
-    if (!commonDelegate) return undefined;
 
     if (devUseFixtureData)
         return {

--- a/packages/webapp/src/elections/api/fixtures.ts
+++ b/packages/webapp/src/elections/api/fixtures.ts
@@ -1,4 +1,9 @@
-import { CurrentElection, ElectionState, VoteData } from "elections/interfaces";
+import {
+    CurrentElection,
+    ElectionState,
+    ElectionStatus,
+    VoteData,
+} from "elections/interfaces";
 
 // The following fixtures represent the following Election/round layout
 // Round 1:
@@ -31,7 +36,7 @@ export const fixtureElectionState: ElectionState = {
 };
 
 export const fixtureRegistrationElection: CurrentElection = {
-    electionState: "current_election_state_registration",
+    electionState: ElectionStatus.Registration,
     start_time: "2022-01-16T16:00:00.000",
     election_threshold: 100,
 };

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -19,12 +19,14 @@ export const CompletedRoundSegment = ({
 }: CompletedRoundSegmentProps) => {
     // TODO: Participants should be limited to only those in the round (we're getting extras right now)
     const { data } = useParticipantsInCompletedRound(roundIndex);
-    const { data: participantsMemberData } = useMemberDataFromEdenMembers(data);
+    const { data: participantsMemberData } = useMemberDataFromEdenMembers(
+        data?.participants
+    );
     console.log("ROUND PARTICIPANTS:", data);
 
     if (!participantsMemberData || !participantsMemberData.length) return <></>; // TODO: Return something here.
 
-    const winner = participantsMemberData[2]; // TODO: This should be the real winner; I'm just picking a random one for now.
+    const winner = data?.participants.find((p) => p.account === data.delegate);
 
     return (
         <Expander

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -20,14 +20,8 @@ interface CompletedRoundSegmentProps {
 export const CompletedRoundSegment = ({
     roundIndex,
 }: CompletedRoundSegmentProps) => {
-    const { data: loggedInMember } = useCurrentMember();
-    console.info(
-        `roundIndex[${roundIndex}], loggedInMember[${loggedInMember}]`
-    );
-
     const { data: roundParticipants } = useParticipantsInCompletedRound(
-        roundIndex,
-        loggedInMember
+        roundIndex
     );
     console.log("ROUND PARTICIPANTS:", roundParticipants);
     // TODO: The number of completed rounds is generated based on fixture data, but the contents are still mocked. Fill in contents!

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -2,7 +2,7 @@ import { RiVideoUploadLine } from "react-icons/ri";
 
 import {
     useMemberDataFromEdenMembers,
-    useParticipantsInCompletedRound,
+    useParticipantsInMyCompletedRound,
 } from "_app";
 import { Button, Container, Expander } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
@@ -18,7 +18,7 @@ export const CompletedRoundSegment = ({
     roundIndex,
 }: CompletedRoundSegmentProps) => {
     // TODO: Participants should be limited to only those in the round (we're getting extras right now)
-    const { data } = useParticipantsInCompletedRound(roundIndex);
+    const { data } = useParticipantsInMyCompletedRound(roundIndex);
     const { data: participantsMemberData } = useMemberDataFromEdenMembers(
         data?.participants
     );

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -5,6 +5,7 @@ import {
     queryMembers,
     useCurrentMember,
     useParticipantsInCompletedRound,
+    useVoteDataRow,
 } from "_app";
 import { Button, Container, Expander } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
@@ -20,6 +21,10 @@ export const CompletedRoundSegment = ({
     roundIndex,
 }: CompletedRoundSegmentProps) => {
     const { data: loggedInMember } = useCurrentMember();
+    console.info(
+        `roundIndex[${roundIndex}], loggedInMember[${loggedInMember}]`
+    );
+
     const { data: roundParticipants } = useParticipantsInCompletedRound(
         roundIndex,
         loggedInMember

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -22,7 +22,6 @@ export const CompletedRoundSegment = ({
     const { data: participantsMemberData } = useMemberDataFromEdenMembers(
         data?.participants
     );
-    console.log("ROUND PARTICIPANTS:", data);
 
     if (!participantsMemberData || !participantsMemberData.length) return <></>; // TODO: Return something here.
 
@@ -32,7 +31,7 @@ export const CompletedRoundSegment = ({
         <Expander
             header={
                 <RoundHeader
-                    roundNum={roundIndex + 1}
+                    roundIndex={roundIndex}
                     subText={
                         winner
                             ? `Delegate elect: ${winner.name}`

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -1,7 +1,11 @@
 import { useQuery } from "react-query";
 import { RiVideoUploadLine } from "react-icons/ri";
 
-import { queryMembers } from "_app";
+import {
+    queryMembers,
+    useCurrentMember,
+    useParticipantsInCompletedRound,
+} from "_app";
 import { Button, Container, Expander } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
 import { MembersGrid } from "members";
@@ -9,12 +13,18 @@ import { MembersGrid } from "members";
 import RoundHeader from "./round-header";
 
 interface CompletedRoundSegmentProps {
-    round: number;
+    roundIndex: number;
 }
 
 export const CompletedRoundSegment = ({
-    round,
+    roundIndex,
 }: CompletedRoundSegmentProps) => {
+    const { data: loggedInMember } = useCurrentMember();
+    const { data: roundParticipants } = useParticipantsInCompletedRound(
+        roundIndex,
+        loggedInMember
+    );
+    console.log("ROUND PARTICIPANTS:", roundParticipants);
     // TODO: The number of completed rounds is generated based on fixture data, but the contents are still mocked. Fill in contents!
     const { data: participants } = useQuery({
         ...queryMembers(1, 5),
@@ -29,7 +39,7 @@ export const CompletedRoundSegment = ({
         <Expander
             header={
                 <RoundHeader
-                    roundNum={round}
+                    roundNum={roundIndex + 1}
                     subText={
                         winner
                             ? `Delegate elect: ${winner.name}`
@@ -44,7 +54,7 @@ export const CompletedRoundSegment = ({
                     if (member.account === winner?.account) {
                         return (
                             <ElectionParticipantChip
-                                key={`round-${round}-winner`}
+                                key={`round-${roundIndex + 1}-winner`}
                                 member={member}
                                 delegateLevel="Delegate elect"
                                 electionVideoCid="QmeKPeuSai8sbEfvbuVXzQUzYRsntL3KSj5Xok7eRiX5Fp/edenTest2ElectionRoom12.mp4"
@@ -53,7 +63,9 @@ export const CompletedRoundSegment = ({
                     }
                     return (
                         <ElectionParticipantChip
-                            key={`round-${round}-participant-${member.account}`}
+                            key={`round-${roundIndex + 1}-participant-${
+                                member.account
+                            }`}
                             member={member}
                         />
                     );
@@ -62,7 +74,7 @@ export const CompletedRoundSegment = ({
             <Container>
                 <Button size="sm">
                     <RiVideoUploadLine size={18} className="mr-2" />
-                    Upload round {round} recording
+                    Upload round {roundIndex + 1} recording
                 </Button>
             </Container>
         </Expander>

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -1,11 +1,8 @@
-import { useQuery } from "react-query";
 import { RiVideoUploadLine } from "react-icons/ri";
 
 import {
-    queryMembers,
-    useCurrentMember,
+    useMemberDataFromEdenMembers,
     useParticipantsInCompletedRound,
-    useVoteDataRow,
 } from "_app";
 import { Button, Container, Expander } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
@@ -20,19 +17,14 @@ interface CompletedRoundSegmentProps {
 export const CompletedRoundSegment = ({
     roundIndex,
 }: CompletedRoundSegmentProps) => {
-    const { data: roundParticipants } = useParticipantsInCompletedRound(
-        roundIndex
-    );
-    console.log("ROUND PARTICIPANTS:", roundParticipants);
-    // TODO: The number of completed rounds is generated based on fixture data, but the contents are still mocked. Fill in contents!
-    const { data: participants } = useQuery({
-        ...queryMembers(1, 5),
-        staleTime: Infinity,
-    });
+    // TODO: Participants should be limited to only those in the round (we're getting extras right now)
+    const { data } = useParticipantsInCompletedRound(roundIndex);
+    const { data: participantsMemberData } = useMemberDataFromEdenMembers(data);
+    console.log("ROUND PARTICIPANTS:", data);
 
-    if (!participants) return <></>;
+    if (!participantsMemberData || !participantsMemberData.length) return <></>; // TODO: Return something here.
 
-    const winner = participants[2]; // TODO: This should be the real winner; I'm just picking a random one for now.
+    const winner = participantsMemberData[2]; // TODO: This should be the real winner; I'm just picking a random one for now.
 
     return (
         <Expander
@@ -48,7 +40,7 @@ export const CompletedRoundSegment = ({
             }
             inactive
         >
-            <MembersGrid members={participants}>
+            <MembersGrid members={participantsMemberData}>
                 {(member) => {
                     if (member.account === winner?.account) {
                         return (

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
@@ -246,7 +246,7 @@ export const OngoingRoundSegment = ({
                     </Button>
                     <Button size="sm">
                         <RiVideoUploadLine size={18} className="mr-2" />
-                        Upload round {roundData.round} recording
+                        Upload round {roundData.round + 1} recording
                     </Button>
                 </div>
             </Container>

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
@@ -108,6 +108,7 @@ export const OngoingRoundSegment = ({
             console.info("electopt trx", signedTrx);
 
             // invalidate current member query to update participating status
+            await new Promise((resolve) => setTimeout(resolve, 3000));
             queryClient.invalidateQueries(
                 queryMemberGroupParticipants(
                     loggedInMember?.account,
@@ -115,6 +116,7 @@ export const OngoingRoundSegment = ({
                 ).queryKey
             );
         } catch (error) {
+            // TODO: Alert of failure...e.g., vote comes in after voting closes.
             console.error(error);
         }
         setIsLoading(false);
@@ -260,7 +262,9 @@ export const OngoingRoundSegment = ({
                         onClick={onSubmitVote}
                         isLoading={isLoading}
                     >
-                        <BiCheck size={21} className="-mt-1 mr-1" />
+                        {!isLoading && (
+                            <BiCheck size={21} className="-mt-1 mr-1" />
+                        )}
                         {userVotingFor ? "Change Vote" : "Submit Vote"}
                     </Button>
                     <Button size="sm">

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
@@ -93,11 +93,9 @@ export const OngoingRoundSegment = ({
                 roundIndex,
                 selectedMember?.account
             );
-            console.info("signing trx", transaction);
             const signedTrx = await ualAccount.signTransaction(transaction, {
                 broadcast: true,
             });
-            console.info("electopt trx", signedTrx);
 
             // invalidate current member query to update participating status
             await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
@@ -10,9 +10,11 @@ import {
     useCurrentMember,
     useMemberGroupParticipants,
     useMemberListByAccountNames,
+    useVoteData,
 } from "_app/hooks/queries";
 import { Button, Container, Expander, Heading, Text } from "_app/ui";
 import { VotingMemberChip } from "elections";
+import { ElectionRoundData } from "elections/interfaces";
 import { MembersGrid } from "members";
 import { EdenMember, MemberData } from "members/interfaces";
 import { setVote } from "../../transactions";
@@ -22,7 +24,7 @@ import PasswordPromptModal from "./password-prompt-modal";
 import RoundHeader from "./round-header";
 
 interface OngoingRoundSegmentProps {
-    roundData: any;
+    roundData: ElectionRoundData;
 }
 
 // TODO: Much of the building up of the data shouldn't be done in the UI layer. What do we want the API to provide? What data does this UI really need? We could even define a new OngoingElection type to provide to this UI.
@@ -45,9 +47,18 @@ export const OngoingRoundSegment = ({
     const [ualAccount] = useUALAccount();
     const { data: loggedInMember } = useCurrentMember();
 
-    const { data: voteData } = useMemberGroupParticipants(
+    const { data: memberGroup } = useMemberGroupParticipants(
         loggedInMember?.account
     );
+
+    const { data: allVoteData } = useVoteData(
+        { limit: 20 },
+        {
+            enabled: roundData.electionState === "current_election_state_final", // TODO: Enum!
+        }
+    );
+
+    const voteData = memberGroup ?? allVoteData;
 
     const roundEdenMembers = useMemberListByAccountNames(
         voteData?.map((participant) => participant.member) ?? []

--- a/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
@@ -41,7 +41,7 @@ export const RoundHeader = ({
                 )}
                 <div>
                     <Text size="sm" className="font-semibold">
-                        Round {roundNum ?? roundData.round}
+                        Round {roundNum ?? roundData.round + 1}
                     </Text>
                     <Text size="sm" className="tracking-tight">
                         {subHeader}

--- a/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
@@ -7,16 +7,16 @@ import { Text } from "_app/ui";
 import { CountdownPieMer } from "elections";
 
 type RoundHeaderProps =
-    | { roundData: any; roundNum?: number; subText?: string }
-    | { roundData?: any; roundNum: number; subText: string };
+    | { roundEndTime: string; roundIndex: number; subText?: string }
+    | { roundEndTime?: string; roundIndex: number; subText: string };
 
 export const RoundHeader = ({
-    roundData,
-    roundNum,
+    roundEndTime,
+    roundIndex,
     subText,
 }: RoundHeaderProps) => {
-    const isActive = Boolean(roundData);
-    const endsAt = isActive ? dayjs(roundData.round_end + "Z") : undefined;
+    const isActive = Boolean(roundEndTime);
+    const endsAt = isActive ? dayjs(roundEndTime + "Z") : undefined;
     const startsAt = endsAt && endsAt.subtract(40, "minute");
     let subHeader = subText;
 
@@ -41,7 +41,7 @@ export const RoundHeader = ({
                 )}
                 <div>
                     <Text size="sm" className="font-semibold">
-                        Round {roundNum ?? roundData.round + 1}
+                        Round {roundIndex + 1}
                     </Text>
                     <Text size="sm" className="tracking-tight">
                         {subHeader}

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -1,10 +1,9 @@
 import { useCurrentElection, useMemberStats } from "_app";
 import { Container, Heading, Text } from "_app/ui";
-import { ElectionRoundData } from "elections/interfaces";
+import { ElectionRoundData, ElectionStatus } from "elections/interfaces";
 
 import * as Ongoing from "./ongoing-election-components";
 
-// TODO: Hook up to real/fixture data; break apart and organize
 // TODO: Make sure time zone changes during election are handled properly
 export const OngoingElection = () => {
     const { data: currentElection } = useCurrentElection();
@@ -19,7 +18,7 @@ export const OngoingElection = () => {
     }
 
     let roundData = currentElection as ElectionRoundData;
-    if (currentElection?.electionState === "current_election_state_final") {
+    if (currentElection?.electionState === ElectionStatus.Final) {
         roundData = {
             electionState: currentElection?.electionState,
             round: memberStats?.ranks.length,
@@ -35,7 +34,7 @@ export const OngoingElection = () => {
                 <Text>In progress until 6:30pm EDT</Text>
             </Container>
             <Ongoing.SupportSegment />
-            {/* TODO: How do we get previous round info? Do that here. */}
+            {/* TODO: How do we get previous round info for rounds that didn't come to consensus? Do that here. */}
             {roundData?.round > 0 &&
                 [...Array(roundData.round)].map((_, i) => (
                     <Ongoing.CompletedRoundSegment
@@ -44,7 +43,12 @@ export const OngoingElection = () => {
                     />
                 ))}
             {currentElection && (
-                <Ongoing.OngoingRoundSegment roundData={roundData} />
+                <Ongoing.OngoingRoundSegment
+                    electionState={roundData.electionState}
+                    roundIndex={roundData.round}
+                    roundEndTime={roundData.round_end}
+                    electionConfig={roundData.config}
+                />
             )}
         </div>
     );

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -1,5 +1,6 @@
-import { useCurrentElection } from "_app";
+import { useCurrentElection, useMemberStats } from "_app";
 import { Container, Heading, Text } from "_app/ui";
+import { ElectionRoundData } from "elections/interfaces";
 
 import * as Ongoing from "./ongoing-election-components";
 
@@ -7,6 +8,25 @@ import * as Ongoing from "./ongoing-election-components";
 // TODO: Make sure time zone changes during election are handled properly
 export const OngoingElection = () => {
     const { data: currentElection } = useCurrentElection();
+    const { data: memberStats } = useMemberStats();
+
+    if (!currentElection || !memberStats) {
+        return (
+            <Container>
+                <Heading size={2}>Loading</Heading>
+            </Container>
+        );
+    }
+
+    let roundData = currentElection as ElectionRoundData;
+    if (currentElection?.electionState === "current_election_state_final") {
+        roundData = {
+            electionState: currentElection?.electionState,
+            round: memberStats?.ranks.length,
+            // TODO: Reduce time for sortition round to two hours in contract
+            round_end: currentElection?.seed.end_time,
+        };
+    }
 
     return (
         <div className="divide-y">
@@ -16,15 +36,15 @@ export const OngoingElection = () => {
             </Container>
             <Ongoing.SupportSegment />
             {/* TODO: How do we get previous round info? Do that here. */}
-            {currentElection?.round > 0 &&
-                [...Array(currentElection.round)].map((_, i) => (
+            {roundData?.round > 0 &&
+                [...Array(roundData.round)].map((_, i) => (
                     <Ongoing.CompletedRoundSegment
                         key={`election-round-${i + 1}`}
                         round={i + 1}
                     />
                 ))}
             {currentElection && (
-                <Ongoing.OngoingRoundSegment roundData={currentElection} />
+                <Ongoing.OngoingRoundSegment roundData={roundData} />
             )}
         </div>
     );

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -16,8 +16,8 @@ export const OngoingElection = () => {
             </Container>
             <Ongoing.SupportSegment />
             {/* TODO: How do we get previous round info? Do that here. */}
-            {currentElection?.round &&
-                [...Array(currentElection.round - 1)].map((_, i) => (
+            {currentElection?.round > 0 &&
+                [...Array(currentElection.round)].map((_, i) => (
                     <Ongoing.CompletedRoundSegment
                         key={`election-round-${i + 1}`}
                         round={i + 1}

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -40,7 +40,7 @@ export const OngoingElection = () => {
                 [...Array(roundData.round)].map((_, i) => (
                     <Ongoing.CompletedRoundSegment
                         key={`election-round-${i + 1}`}
-                        round={i + 1}
+                        roundIndex={i}
                     />
                 ))}
             {currentElection && (

--- a/packages/webapp/src/elections/interfaces.ts
+++ b/packages/webapp/src/elections/interfaces.ts
@@ -71,3 +71,10 @@ export interface VoteData {
     index: number;
     candidate: string;
 }
+
+export interface ElectionRoundData {
+    electionState: string;
+    round: number;
+    round_end: string;
+    config?: ActiveStateConfigType;
+}

--- a/packages/webapp/src/elections/interfaces.ts
+++ b/packages/webapp/src/elections/interfaces.ts
@@ -4,6 +4,16 @@ export interface ElectionState {
     last_election_time: string;
 }
 
+export enum ElectionStatus {
+    PendingDate = "current_election_state_pending_date",
+    Registration = "current_election_state_registration",
+    Seeding = "current_election_state_seeding",
+    Voters = "current_election_state_init_voters",
+    Active = "current_election_state_active",
+    Round = "current_election_state_post_round",
+    Final = "current_election_state_final",
+}
+
 interface CurrentElection_registrationState {
     start_time: string;
     election_threshold?: number;

--- a/packages/webapp/src/elections/transactions.ts
+++ b/packages/webapp/src/elections/transactions.ts
@@ -50,3 +50,27 @@ export const setElectionParticipation = (
         },
     ],
 });
+
+export const setVote = (
+    authorizerAccount: string,
+    round: number,
+    candidate: string
+) => ({
+    actions: [
+        {
+            account: edenContractAccount,
+            name: "electvote",
+            authorization: [
+                {
+                    actor: authorizerAccount,
+                    permission: "active",
+                },
+            ],
+            data: {
+                round,
+                voter: authorizerAccount,
+                candidate,
+            },
+        },
+    ],
+});

--- a/packages/webapp/src/members/interfaces.ts
+++ b/packages/webapp/src/members/interfaces.ts
@@ -1,7 +1,8 @@
 import { EdenNftSocialHandles } from "nfts/interfaces";
 import { Asset, ElectionParticipationStatus, MemberStatus } from "_app";
+import { TableQueryOptions } from "_app/eos/interfaces";
 
-export type VoteDataQueryOptionsByGroup = {
+export type VoteDataQueryOptionsByGroup = TableQueryOptions & {
     index_position?: 2;
     lowerBound: number;
     upperBound: number;

--- a/packages/webapp/src/members/interfaces.ts
+++ b/packages/webapp/src/members/interfaces.ts
@@ -4,8 +4,8 @@ import { TableQueryOptions } from "_app/eos/interfaces";
 
 export type VoteDataQueryOptionsByGroup = TableQueryOptions & {
     index_position?: 2;
-    lowerBound: number;
-    upperBound: number;
+    lowerBound?: number;
+    upperBound?: number;
 };
 
 export type VoteDataQueryOptionsByField = {

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -101,7 +101,7 @@ const Delegates = ({
     return (
         <>
             {myDelegation
-                .slice(0, membersStats.ranks.length - 2)
+                .slice(0, heightOfDelegationWithoutChiefs)
                 .map((delegate, index) => (
                     <div
                         className="-mt-px"
@@ -187,7 +187,7 @@ const Chiefs = () => {
             </Container>
             <DelegateChip
                 member={headChiefAsMemberData}
-                level={headChiefAsEdenMember.election_rank}
+                level={headChiefAsEdenMember.election_rank + 1}
             />
         </>
     );

--- a/packages/webapp/src/pages/election/data.tsx
+++ b/packages/webapp/src/pages/election/data.tsx
@@ -13,7 +13,7 @@ import {
     useElectionState,
     useHeadDelegate,
     useMemberGroupParticipants,
-    useParticipantsInCompletedRound,
+    useParticipantsInMyCompletedRound,
     useVoteDataRow,
 } from "_app";
 
@@ -27,7 +27,7 @@ export const ElectionPage = () => {
 
     const {
         data: participantsInCompletedRound,
-    } = useParticipantsInCompletedRound(targetRound, loggedInMember);
+    } = useParticipantsInMyCompletedRound(targetRound);
 
     const { data: voteRowForLoggedInMember } = useVoteDataRow(
         loggedInMember?.account

--- a/packages/webapp/src/pages/election/index.tsx
+++ b/packages/webapp/src/pages/election/index.tsx
@@ -1,6 +1,7 @@
 import { FluidLayout, useCurrentElection } from "_app";
 import { Container, Heading } from "_app/ui";
 import { OngoingElection, RegistrationElection } from "elections";
+import { ElectionStatus } from "elections/interfaces";
 import { EncryptionPasswordAlert } from "encryption";
 
 export const ElectionPage = () => {
@@ -24,10 +25,10 @@ export const ElectionPage = () => {
 
 const ElectionBody = ({ electionState }: { electionState?: string }) => {
     switch (electionState) {
-        case "current_election_state_registration":
+        case ElectionStatus.Registration:
             return <RegistrationElection />;
-        case "current_election_state_active":
-        case "current_election_state_final": // TODO: This is one state where there's a board but no satoshi. UI should reflect that.
+        case ElectionStatus.Active:
+        case ElectionStatus.Final: // TODO: This is one state where there's a board but no satoshi. UI should reflect that.
             return <OngoingElection />;
         default:
             return (

--- a/packages/webapp/src/pages/election/index.tsx
+++ b/packages/webapp/src/pages/election/index.tsx
@@ -27,6 +27,7 @@ const ElectionBody = ({ electionState }: { electionState?: string }) => {
         case "current_election_state_registration":
             return <RegistrationElection />;
         case "current_election_state_active":
+        case "current_election_state_final": // TODO: This is one state where there's a board but no satoshi. UI should reflect that.
             return <OngoingElection />;
         default:
             return (

--- a/packages/webapp/src/pages/election/index.tsx
+++ b/packages/webapp/src/pages/election/index.tsx
@@ -16,15 +16,25 @@ export const ElectionPage = () => {
                 <Container>
                     <Heading size={1}>Election</Heading>
                 </Container>
-                {currentElection?.electionState ===
-                "current_election_state_registration" ? (
-                    <RegistrationElection />
-                ) : (
-                    <OngoingElection />
-                )}
+                <ElectionBody electionState={currentElection?.electionState} />
             </div>
         </FluidLayout>
     );
+};
+
+const ElectionBody = ({ electionState }: { electionState?: string }) => {
+    switch (electionState) {
+        case "current_election_state_registration":
+            return <RegistrationElection />;
+        case "current_election_state_active":
+            return <OngoingElection />;
+        default:
+            return (
+                <Container>
+                    <Heading size={2}>Unhandled state</Heading>
+                </Container>
+            );
+    }
 };
 
 export default ElectionPage;


### PR DESCRIPTION
Purpose of this PR is to hook up _existing_ ongoing-election UI to real, life contract table data. 

## In This PR
- [x] Get in-election round group queries to work
- [x] Tweak ongoing-election UI to match data coming in better
- [x] Vote action
- [x] Hook up previous round data (if round came to consensus)
- [x] Polling for votes / UI magically updates

## Future Work
- How do we display (during an election) prior rounds that did _not_ come to consensus? Can we query that?
- Differentiate Chief Delegates round (label as Chief Delegates, no voting, explainer, etc.)
- Signed out / non-member view
- Views for someone who doesn't become a delegate at a various points during the election
- Bigger refactors
- etc.

In this PR, we're prioritizing functionality. In other words, I just want to get it working. We will refactor later. So be gentle. ;)