### PR TITLE
Completes fn to generate meeting and publish to Chain

### DIFF
--- a/packages/webapp/src/_api/schemas/meetings.ts
+++ b/packages/webapp/src/_api/schemas/meetings.ts
@@ -7,5 +7,8 @@ export enum AvailableMeetingClients {
 export const meetingLinkRequestSchema = z.object({
     client: z.nativeEnum(AvailableMeetingClients),
     accessToken: z.string(),
+    topic: z.string(),
+    duration: z.number(),
+    startTime: z.string(),
 });
 export type MeetingLinkRequest = z.infer<typeof meetingLinkRequestSchema>;

--- a/packages/webapp/src/_api/zoom-commons.ts
+++ b/packages/webapp/src/_api/zoom-commons.ts
@@ -62,7 +62,7 @@ export const zoomResponseIsInvalidAccess = (response: any) => {
 
 export const generateZoomMeetingLink = async (
     zoomAccountJWT: any,
-    setZoomAccountJWT: () => void,
+    setZoomAccountJWT: (updatedJwt: any) => void,
     topic: string,
     durationInMinutes: number,
     startTime: string

--- a/packages/webapp/src/_api/zoom-commons.ts
+++ b/packages/webapp/src/_api/zoom-commons.ts
@@ -1,5 +1,7 @@
 import { zoom } from "config";
 
+import { AvailableMeetingClients } from "./schemas";
+
 export const ZOOM_AUTHORIZATION = Buffer.from(
     zoom.clientKey + ":" + zoom.clientSecret
 ).toString("base64");
@@ -56,4 +58,52 @@ export const zoomAccountJWTIsExpired = (zoomAccountJWT: ZoomAccountJWT) => {
 
 export const zoomResponseIsInvalidAccess = (response: any) => {
     return response && response.error && response.error.code === 124; // invalid access token
+};
+
+export const generateZoomMeetingLink = async (
+    zoomAccountJWT: any,
+    setZoomAccountJWT: () => void,
+    topic: string,
+    durationInMinutes: number,
+    startTime: string
+) => {
+    let accessToken = zoomAccountJWT.access_token;
+    if (!accessToken) {
+        throw new Error("Invalid AccessToken");
+    }
+
+    if (zoomAccountJWTIsExpired(zoomAccountJWT)) {
+        const newTokensResponse = await fetch(`/api/refresh-zoom`, {
+            method: "POST",
+            body: JSON.stringify({
+                refreshToken: zoomAccountJWT.refresh_token,
+            }),
+        });
+
+        const newTokens = await newTokensResponse.json();
+        if (!newTokensResponse.ok) {
+            setZoomAccountJWT(undefined);
+        }
+
+        setZoomAccountJWT(newTokens);
+        accessToken = newTokens.access_token;
+    }
+
+    const response = await fetch(`/api/meeting-links`, {
+        method: "POST",
+        body: JSON.stringify({
+            accessToken,
+            client: AvailableMeetingClients.Zoom,
+            topic,
+            duration: durationInMinutes,
+            startTime,
+        }),
+    });
+
+    const responseData = await response.json();
+    if (zoomResponseIsInvalidAccess(responseData)) {
+        setZoomAccountJWT(undefined);
+    }
+
+    return responseData;
 };

--- a/packages/webapp/src/_app/eos/secret-publisher.ts
+++ b/packages/webapp/src/_app/eos/secret-publisher.ts
@@ -46,7 +46,7 @@ export const encryptSecretForPublishing = async (
     const transientKeyPair = generateEncryptionKey();
     console.info(transientKeyPair);
 
-    const keks = await ecdhRecipientsKeyEncriptionKeys(
+    const keks = await ecdhRecipientsKeyEncryptionKeys(
         publicKeys,
         transientKeyPair.privateKey,
         info
@@ -177,7 +177,7 @@ const validateFetchedKeys = (
     return [publisherKey, ...recipientKeys];
 };
 
-const ecdhRecipientsKeyEncriptionKeys = async (
+const ecdhRecipientsKeyEncryptionKeys = async (
     recipientPublicKeys: string[],
     transientPrivateKey: PrivateKey,
     info?: string

--- a/packages/webapp/src/_app/eos/secret-publisher.ts
+++ b/packages/webapp/src/_app/eos/secret-publisher.ts
@@ -1,4 +1,4 @@
-import { getEncryptionKey } from "encryption";
+import { EncryptedKey, getEncryptionKey } from "encryption";
 import { PrivateKey, PublicKey } from "eosjs/dist/eosjs-jssig";
 import { generateKeyPair } from "eosjs/dist/eosjs-key-conversions";
 import { KeyType } from "eosjs/dist/eosjs-numeric";
@@ -37,7 +37,7 @@ export const encryptSecretForPublishing = async (
         queryClient
     );
 
-    const [publisherKey, ...recipientKeys] = validateFetchedKeys(
+    const publicKeys = validateFetchedKeys(
         accountKeys,
         publisherAccount,
         recipientAccounts
@@ -47,11 +47,11 @@ export const encryptSecretForPublishing = async (
     console.info(transientKeyPair);
 
     const keks = await ecdhRecipientsKeyEncriptionKeys(
-        [publisherKey, ...recipientKeys],
+        publicKeys,
         transientKeyPair.privateKey,
         info
     );
-    console.info(keks);
+    console.info(publicKeys, keks);
 
     const sessionKey = await generateRandomSessionKey();
     console.info("session key", sessionKey);
@@ -61,25 +61,40 @@ export const encryptSecretForPublishing = async (
 
     const encryptedMessage = await encryptMessage(sessionKey, message);
 
-    console.info({
-        encryptedSessionKeys,
-        publisherKey,
-        recipientKeys,
-        transientKeyPair,
-        encryptedMessage,
-    });
+    const publisherKey = publicKeys[0];
+    const contractFormatEncryptedKeys: EncryptedKey[] = encryptedSessionKeys.map(
+        (encryptedKey, i) => ({
+            sender_key: publisherKey,
+            recipient_key: publicKeys[i],
+            key: encryptedKey,
+        })
+    );
 
-    // TODO: remove this test
-    console.info("testing decryption...");
-    await decryptPublishedMessage(
+    const decryptedMessage = await decryptPublishedMessage(
         encryptedMessage,
         publisherKey,
         transientKeyPair.publicKey.toString(),
         encryptedSessionKeys[0],
         info
     );
+    if (decryptedMessage !== message) {
+        throw new Error(
+            "an error occurred during encryption/decryption of the data"
+        );
+    }
 
-    return {};
+    console.info({
+        encryptedSessionKeys,
+        contractFormatEncryptedKeys,
+        publicKeys,
+        transientKeyPair,
+        encryptedMessage,
+    });
+
+    return {
+        contractFormatEncryptedKeys,
+        encryptedMessage,
+    };
 };
 
 export const decryptPublishedMessage = async (
@@ -108,9 +123,10 @@ export const generateEncryptionKey = () =>
     generateKeyPair(KeyType.k1, { secureEnv: true });
 
 const retrieveRecipientPrivateKey = (publicKey: string): PrivateKey => {
-    // TODO: find the corresponding private key in the localstorage, or else throw
-    console.info("retrieving publicKey...");
-    const rawPrivateKey = "5KcMypBPGByXbeBphsVzyyzUvg31tWNKsgrfXs2MmanYgYf4gao";
+    const rawPrivateKey = getEncryptionKey(publicKey);
+    if (!rawPrivateKey) {
+        throw new Error("fail to retrieve private key for decrypting message");
+    }
     return PrivateKey.fromString(rawPrivateKey);
 };
 

--- a/packages/webapp/src/elections/index.ts
+++ b/packages/webapp/src/elections/index.ts
@@ -1,1 +1,2 @@
 export * from "./components";
+export * from "./transactions";

--- a/packages/webapp/src/elections/transactions.ts
+++ b/packages/webapp/src/elections/transactions.ts
@@ -3,7 +3,7 @@ import { EncryptedKey } from "encryption";
 
 export const setElectionMeeting = (
     authorizerAccount: string,
-    round: number,
+    id: number,
     keys: EncryptedKey[],
     data: Uint8Array,
     old_data?: Uint8Array
@@ -20,7 +20,7 @@ export const setElectionMeeting = (
             ],
             data: {
                 account: authorizerAccount,
-                round,
+                id,
                 keys,
                 data,
                 old_data,

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -13,6 +13,8 @@ export const fixtureEdenMembers: EdenMember[] = [
         // representative field will be same as account field for Head Chief
         // see isValidDelegate() for other special values and their meaning
         representative: "alice.edev", // "parent" field
+        encryption_key: "EOS87dKR7L6D4jZPj9XNN4H2pQavaAvWHdasFZZQCdu8Vn9ro5aDf",
+        // PK for above key is: 5J6YvXREKBypzFYVC2uEcw3sLE1dUrYwGZ1yatMArJRgRCN8S81
     },
     {
         name: "Egeon The Great",
@@ -23,10 +25,12 @@ export const fixtureEdenMembers: EdenMember[] = [
             ElectionParticipationStatus.NotInElection,
         election_rank: 3,
         representative: "alice.edev",
+        encryption_key: "EOS85AkeYxLXd3FHb9fk9R4xJfxm8PjLSbDosW33cviiKpm2HUJBT",
+        // pk for above key is: 5Jkoj5KXqQ6mHaLs4QMH4YktfsEZK86hxtXdJ78qXxkBHnVBftE
     },
     {
         name: "Philip Pip",
-        account: "pip.edev",
+        account: "pip2.edev",
         nft_template_id: 147802,
         status: MemberStatus.ActiveMember,
         election_participation_status:

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -30,7 +30,7 @@ export const fixtureEdenMembers: EdenMember[] = [
     },
     {
         name: "Philip Pip",
-        account: "pip2.edev",
+        account: "pip.edev",
         nft_template_id: 147802,
         status: MemberStatus.ActiveMember,
         election_participation_status:

--- a/packages/webapp/src/pages/api/meeting-links.ts
+++ b/packages/webapp/src/pages/api/meeting-links.ts
@@ -39,7 +39,7 @@ export const generateMeeting = async (meetingRequest: MeetingLinkRequest) => {
     console.info(meetingRequest);
     switch (meetingRequest.client as AvailableMeetingClients) {
         case AvailableMeetingClients.Zoom:
-            return generateZoomMeeting(meetingRequest.accessToken);
+            return generateZoomMeeting(meetingRequest);
         default:
             throw new BadRequestError("meeting client not supported");
     }
@@ -49,13 +49,11 @@ export const generateMeeting = async (meetingRequest: MeetingLinkRequest) => {
  * Zoom Meeting Create API can be found here:
  * https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingcreate
  */
-const generateZoomMeeting = async (accessToken: string) => {
+const generateZoomMeeting = async (meetingRequest: MeetingLinkRequest) => {
     const body = {
-        topic: `Test Eden Election #${Math.floor(Math.random() * 100_000_000)}`,
-        duration: 40,
-        start_time: `2025-08-15T${Math.floor(Math.random() * 23)}:${Math.floor(
-            Math.random() * 59
-        )}:00Z`,
+        topic: meetingRequest.topic,
+        duration: meetingRequest.duration,
+        start_time: meetingRequest.startTime,
         password: uuidv4().substr(0, 8),
         settings: {
             join_before_host: true,
@@ -68,7 +66,7 @@ const generateZoomMeeting = async (accessToken: string) => {
     const response = await fetch(`https://api.zoom.us/v2/users/me/meetings`, {
         method: "POST",
         headers: {
-            Authorization: `Bearer ${accessToken}`,
+            Authorization: `Bearer ${meetingRequest.accessToken}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify(body),


### PR DESCRIPTION
- Completes the link between the encryption function and the meeting generation in the zoom oauth page.
- The function generateZoomMeetingLink can be reused from our correct elections flow (as opposed to the current dummy example)
- Then right after we should use `encryptSecretForPublishing` and `setInductMeeting` to publish to the chain.

PS: Should work after #393 abi is deployed. We got an abi parameters issue.