### PR TITLE
Ongoing Election: Slimmed-Down Chief Delegates Round Section

### DIFF
--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -83,11 +83,6 @@ export const VotingMemberChip = ({
     );
 };
 
-interface DelegateChipProps {
-    member?: MemberData;
-    level?: number;
-}
-
 const getDelegateLevelDescription = (
     memberAccount: string | undefined,
     level: number | undefined
@@ -105,10 +100,22 @@ const getDelegateLevelDescription = (
     return prefix;
 };
 
-export const DelegateChip = ({ member, level }: DelegateChipProps) => (
+interface DelegateChipProps {
+    member?: MemberData;
+    level?: number;
+    delegateTitle?: string;
+}
+
+export const DelegateChip = ({
+    member,
+    level,
+    delegateTitle,
+}: DelegateChipProps) => (
     <ElectionParticipantChip
         member={member}
-        delegateLevel={getDelegateLevelDescription(member?.account, level)}
+        delegateLevel={
+            delegateTitle ?? getDelegateLevelDescription(member?.account, level)
+        }
         isDelegate
     />
 );

--- a/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
@@ -39,6 +39,7 @@ export const ChiefsRoundSegment = ({
                 <RoundHeader
                     roundEndTime={roundEndTime}
                     roundIndex={roundIndex}
+                    headlineText="Chief Delegates Elected - Finalizing"
                 />
             }
             startExpanded
@@ -47,10 +48,15 @@ export const ChiefsRoundSegment = ({
             <Container className="space-y-2">
                 <Heading size={3}>Chief Delegates</Heading>
                 <Text>
-                    In this round, the newly-elected Chief Delegates meet to
-                    discuss their vision for the community. There is no voting
-                    during this round, as the Head Chief is selected randomly in
-                    order to mitigate incumbent advantage.
+                    The new slate of Chief Delegates have officially been
+                    selected! During this time, they may meet to discuss their
+                    vision for the community.
+                </Text>
+                <Text>
+                    There is, however, no voting during this round, as the Head
+                    Chief is selected randomly in order to mitigate incumbent
+                    advantage. That process of randomization is currently
+                    underway.
                 </Text>
             </Container>
             <MembersGrid members={members}>

--- a/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
@@ -33,7 +33,6 @@ export const ChiefsRoundSegment = ({
         (participant) => participant.member === currentMember?.account
     );
 
-    // TODO: DelegateChip: Add configurable string of subtext ("Chief Delegate Elect")
     return (
         <Expander
             header={
@@ -46,16 +45,21 @@ export const ChiefsRoundSegment = ({
             locked
         >
             <Container className="space-y-2">
-                <Heading size={3}>Chief Delegates Elect</Heading>
+                <Heading size={3}>Chief Delegates</Heading>
                 <Text>
                     In this round, the newly-elected Chief Delegates meet to
                     discuss their vision for the community. There is no voting
                     during this round, as the Head Chief is selected randomly in
-                    order to compensate for incumbent advantage.
+                    order to mitigate incumbent advantage.
                 </Text>
             </Container>
             <MembersGrid members={members}>
-                {(member) => <DelegateChip member={member} />}
+                {(member) => (
+                    <DelegateChip
+                        member={member}
+                        delegateTitle="Elected Chief Delegate"
+                    />
+                )}
             </MembersGrid>
             {isUserParticipant && (
                 <Container>

--- a/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
@@ -1,0 +1,74 @@
+import { RiVideoUploadLine } from "react-icons/ri";
+
+import {
+    useCurrentMember,
+    useMemberDataFromVoteData,
+    useVoteData,
+} from "_app/hooks/queries";
+import { Button, Container, Expander, Heading, Text } from "_app/ui";
+import { DelegateChip } from "elections";
+import { MembersGrid } from "members";
+
+import RoundHeader from "./round-header";
+
+interface RoundSegmentProps {
+    roundIndex: number;
+    roundEndTime: string;
+}
+
+// TODO: Much of the building up of the data shouldn't be done in the UI layer. What do we want the API to provide? What data does this UI really need? We could even define a new OngoingElection type to provide to this UI.
+export const ChiefsRoundSegment = ({
+    roundIndex,
+    roundEndTime,
+}: RoundSegmentProps) => {
+    const { data: currentMember } = useCurrentMember();
+    const { data: participantData } = useVoteData({ limit: 20 });
+    const { data: members } = useMemberDataFromVoteData(participantData);
+
+    // TODO: Handle Fetch Errors;
+    if (!members || members?.length !== participantData?.length)
+        return <Text>Error Fetching Members</Text>;
+
+    const isUserParticipant = participantData?.some(
+        (participant) => participant.member === currentMember?.account
+    );
+
+    // TODO: DelegateChip: Add configurable string of subtext ("Chief Delegate Elect")
+    return (
+        <Expander
+            header={
+                <RoundHeader
+                    roundEndTime={roundEndTime}
+                    roundIndex={roundIndex}
+                />
+            }
+            startExpanded
+            locked
+        >
+            <Container className="space-y-2">
+                <Heading size={3}>Chief Delegates Elect</Heading>
+                <Text>
+                    In this round, the newly-elected Chief Delegates meet to
+                    discuss their vision for the community. There is no voting
+                    during this round, as the Head Chief is selected randomly in
+                    order to compensate for incumbent advantage.
+                </Text>
+            </Container>
+            <MembersGrid members={members}>
+                {(member) => <DelegateChip member={member} />}
+            </MembersGrid>
+            {isUserParticipant && (
+                <Container>
+                    <div className="flex flex-col xs:flex-row justify-center space-y-2 xs:space-y-0 xs:space-x-2">
+                        <Button size="sm">
+                            <RiVideoUploadLine size={18} className="mr-2" />
+                            Upload recording
+                        </Button>
+                    </div>
+                </Container>
+            )}
+        </Expander>
+    );
+};
+
+export default ChiefsRoundSegment;

--- a/packages/webapp/src/elections/components/ongoing-election-components/index.ts
+++ b/packages/webapp/src/elections/components/ongoing-election-components/index.ts
@@ -1,3 +1,4 @@
+export * from "./chiefs-round-segment";
 export * from "./completed-round-segment";
 export * from "./consensometer";
 export * from "./ongoing-round-segment";

--- a/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
@@ -7,13 +7,24 @@ import { Text } from "_app/ui";
 import { CountdownPieMer } from "elections";
 
 type RoundHeaderProps =
-    | { roundEndTime: string; roundIndex: number; subText?: string }
-    | { roundEndTime?: string; roundIndex: number; subText: string };
+    | {
+          roundEndTime: string;
+          roundIndex: number;
+          subText?: string;
+          headlineText?: string;
+      }
+    | {
+          roundEndTime?: string;
+          roundIndex: number;
+          subText: string;
+          headlineText?: string;
+      };
 
 export const RoundHeader = ({
     roundEndTime,
     roundIndex,
     subText,
+    headlineText,
 }: RoundHeaderProps) => {
     const isActive = Boolean(roundEndTime);
     const endsAt = isActive ? dayjs(roundEndTime + "Z") : undefined;
@@ -41,7 +52,7 @@ export const RoundHeader = ({
                 )}
                 <div>
                     <Text size="sm" className="font-semibold">
-                        Round {roundIndex + 1}
+                        {headlineText ?? `Round ${roundIndex + 1}`}
                     </Text>
                     <Text size="sm" className="tracking-tight">
                         {subHeader}

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -42,7 +42,12 @@ export const OngoingElection = () => {
                         roundIndex={i}
                     />
                 ))}
-            {currentElection && (
+            {currentElection?.electionState === ElectionStatus.Final ? (
+                <Ongoing.ChiefsRoundSegment
+                    roundIndex={roundData.round}
+                    roundEndTime={roundData.round_end}
+                />
+            ) : (
                 <Ongoing.OngoingRoundSegment
                     electionState={roundData.electionState}
                     roundIndex={roundData.round}


### PR DESCRIPTION
So far, the Chief Delegates round displays exactly like a normal voting round. But they don't get to vote! Their winner is selected by sortition. This brings that UI more in line with that reality.

### In This PR
- Use delegate cards (not vote cards)
- Update wording for round
- Customize sub text on delegates cards: "Chief Delegate Elect"
- Make RoundHeader more customizable with optional headline text
![image](https://user-images.githubusercontent.com/7911424/129102496-ed5a32e3-629a-4617-905d-a6269d959d91.png)
