### PR TITLE
Pre-Election Transitions & UI Enhancements

### DIFF
--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -240,9 +240,10 @@ export const useParticipantsInMyCompletedRound = (electionRound: number) => {
     });
 };
 
-export const useCurrentElection = () =>
-    useQuery({
+export const useCurrentElection = (queryOptions: any = {}) =>
+    useQuery<any, Error>({
         ...queryCurrentElection,
+        ...queryOptions,
     });
 
 export const useMemberGroupParticipants = (memberAccount?: string) => {

--- a/packages/webapp/src/_app/hooks/utils.ts
+++ b/packages/webapp/src/_app/hooks/utils.ts
@@ -21,7 +21,7 @@ export const useInterval = (callback: () => void, delay: number | null) => {
 };
 
 const now = () => new Date();
-const padTime = (time: number) => (time < 10 ? `0${time}` : time);
+const padTime = (time: number) => time.toString().padStart(2, "0");
 
 interface Countdown {
     startTime: Date;

--- a/packages/webapp/src/_app/hooks/utils.ts
+++ b/packages/webapp/src/_app/hooks/utils.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 
 export const useInterval = (callback: () => void, delay: number | null) => {
     const savedCallback = useRef<() => void>(() => {});
@@ -18,4 +18,42 @@ export const useInterval = (callback: () => void, delay: number | null) => {
             return () => clearInterval(id);
         }
     }, [delay]);
+};
+
+const now = () => new Date();
+const padTime = (time: number) => (time < 10 ? `0${time}` : time);
+
+interface Countdown {
+    startTime: Date;
+    endTime: Date;
+    onEnd?: () => void;
+}
+
+export const useCountdown = ({ startTime, endTime, onEnd }: Countdown) => {
+    const [percentDecimal, setPercent] = useState<number>(0);
+
+    const intervalDelay = percentDecimal > 1 ? null : 500;
+    useInterval(() => {
+        const elapsedTimeMs = now().getTime() - startTime.getTime();
+        const durationMs = endTime.getTime() - startTime.getTime();
+        const percentDecimal = elapsedTimeMs / durationMs;
+        setPercent(percentDecimal);
+        if (percentDecimal > 1) onEnd?.();
+    }, intervalDelay);
+
+    const msRemaining = Math.max(endTime.getTime() - now().getTime(), 0);
+    const hrRemaining = Math.floor(msRemaining / 1000 / 60 / 60);
+    const minRemaining = Math.floor(msRemaining / 1000 / 60) % 60;
+    const secRemaining = Math.floor(msRemaining / 1000) % 60;
+
+    return {
+        msRemaining,
+        secRemaining,
+        minRemaining,
+        hrRemaining,
+        percentDecimal,
+        hmmss: `${Boolean(hrRemaining) ? hrRemaining + ":" : ""}${padTime(
+            minRemaining
+        )}:${padTime(secRemaining)}`,
+    };
 };

--- a/packages/webapp/src/_app/ui/loaders.tsx
+++ b/packages/webapp/src/_app/ui/loaders.tsx
@@ -2,8 +2,14 @@ import { FaSpinner } from "react-icons/fa";
 
 import { Card } from "_app";
 
+export const Loader = ({ size = 56 }: { size?: number }) => (
+    <div className="w-full h-full flex justify-center items-center">
+        <FaSpinner size={size} className="animate-spin mr-2 text-gray-700" />
+    </div>
+);
+
 export const LoadingCard = () => (
-    <Card title="Loading...">
-        <FaSpinner className="animate-spin mr-2" />
+    <Card>
+        <Loader />
     </Card>
 );

--- a/packages/webapp/src/_app/ui/pie-status-indicator.tsx
+++ b/packages/webapp/src/_app/ui/pie-status-indicator.tsx
@@ -9,7 +9,7 @@ export const PieStatusIndicator = ({
     percent = 0,
     size = 20,
     backgroundColor = "#e5e5e5",
-    fillColor = "#a3a3a3",
+    fillColor = "#13B981",
 }: Props) => {
     const fillPercent = Math.min(percent, 100);
     return (

--- a/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
@@ -4,7 +4,7 @@ import { FaCheckCircle } from "react-icons/fa";
 import { GoSync } from "react-icons/go";
 
 import { Text } from "_app/ui";
-import { CountdownPieMer } from "elections";
+import { VotePieMer } from "elections";
 
 type RoundHeaderProps =
     | {
@@ -60,7 +60,7 @@ export const RoundHeader = ({
                 </div>
             </div>
             {shouldShowTimer && (
-                <CountdownPieMer
+                <VotePieMer
                     startTime={startsAt!.toDate()}
                     endTime={endsAt!.toDate()}
                     onEnd={() => setShouldShowTimer(false)}

--- a/packages/webapp/src/elections/components/pie-mer.tsx
+++ b/packages/webapp/src/elections/components/pie-mer.tsx
@@ -1,10 +1,5 @@
-import { useState } from "react";
-
-import { useInterval } from "_app";
+import { useCountdown } from "_app";
 import { PieStatusIndicator, Text } from "_app/ui";
-
-const now = () => new Date();
-const padTime = (time: number) => (time < 10 ? `0${time}` : time);
 
 interface Props {
     startTime: Date;
@@ -13,40 +8,29 @@ interface Props {
     onEnd?: () => void;
 }
 
-export const CountdownPieMer = ({
+export const VotePieMer = ({
     startTime,
     endTime,
     className = "",
     onEnd,
 }: Props) => {
-    const [percentDecimal, setPercent] = useState<number>(0);
-
-    const intervalDelay = percentDecimal > 1 ? null : 500;
-    useInterval(() => {
-        const elapsedTimeMs = now().getTime() - startTime.getTime();
-        const durationMs = endTime.getTime() - startTime.getTime();
-        const percentDecimal = elapsedTimeMs / durationMs;
-        setPercent(percentDecimal);
-        if (percentDecimal > 1) onEnd?.();
-    }, intervalDelay);
-
-    const msRemaining = Math.max(endTime.getTime() - now().getTime(), 0);
-    const minutesRemaining = Math.floor(msRemaining / 1000 / 60);
-    const secondsRemaining = Math.floor((msRemaining / 1000) % 60);
+    const countdown = useCountdown({
+        startTime,
+        endTime,
+        onEnd,
+    });
 
     return (
         <div className={`flex items-center ${className}`}>
             <PieStatusIndicator
-                percent={Math.round(percentDecimal * 100)}
+                percent={Math.round(countdown.percentDecimal * 100)}
                 size={28}
             />
             <div className="flex-1 ml-2">
                 <Text size="sm" className="font-semibold">
                     Vote Timer
                 </Text>
-                <Text size="sm">
-                    {padTime(minutesRemaining)}:{padTime(secondsRemaining)}
-                </Text>
+                <Text size="sm">{countdown.hmmss}</Text>
             </div>
         </div>
     );

--- a/packages/webapp/src/elections/components/registration-election-components/election-faq.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/election-faq.tsx
@@ -4,7 +4,7 @@ export const ElectionFAQ = () => {
     return (
         <>
             <Container darkBg>
-                <Heading size={1}>FAQ</Heading>
+                <Heading size={2}>Election FAQ</Heading>
             </Container>
             <Expander header="What is an election like?" darkBg>
                 <Container>Answers coming soon.</Container>

--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -51,11 +51,12 @@ export const ParticipationCard = () => {
 
     const electionDate = electionDates.startDateTime.format("LL");
     const electionStartTime = electionDates.startDateTime.format("LT");
+    const electionStartTimeZone = electionDates.startDateTime.format("z");
     const electionEstimatedEndTime = electionDates.estimatedEndDateTime.format(
         "LT"
     );
     const electionParticipationLimitTime = electionDates.participationTimeLimit.format(
-        "LLL"
+        "LLL (z)"
     );
 
     let statusLabel = "";
@@ -65,8 +66,10 @@ export const ParticipationCard = () => {
     let statusButton = null;
 
     if (!ualAccount) {
-        participationCallLabel = "Sign in to reserve your spot.";
-        statusButton = <Button onClick={ualShowModal}>Sign in</Button>;
+        participationCallLabel = "Sign in to participate.";
+        statusButton = (
+            <Button onClick={ualShowModal}>Sign in to participate</Button>
+        );
     } else if (currentMember) {
         if (
             currentMember.election_participation_status !==
@@ -91,7 +94,9 @@ export const ParticipationCard = () => {
         );
     } else {
         participationCallLabel = "Join Eden to participate!";
-        statusButton = <Button href="/induction">Join Eden</Button>;
+        statusButton = (
+            <Button href="/induction">Join Eden to participate</Button>
+        );
     }
 
     return (
@@ -107,8 +112,8 @@ export const ParticipationCard = () => {
             <Heading size={3}>{statusLabel}</Heading>
             <Text>
                 The next election will be held on {electionDate} between{" "}
-                {electionStartTime} and approximately {electionEstimatedEndTime}
-                .{" "}
+                {electionStartTime} and approximately {electionEstimatedEndTime}{" "}
+                ({electionStartTimeZone}).{" "}
                 <span className="font-semibold">{participationCallLabel}</span>
             </Text>
             {statusButton}
@@ -183,6 +188,7 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
             }
 
             // invalidate current member query to update participating status
+            await new Promise((resolve) => setTimeout(resolve, 3000));
             queryClient.invalidateQueries(
                 queryMemberByAccountName(ualAccount.accountName).queryKey
             );
@@ -217,8 +223,10 @@ const ConfirmParticipationModal = ({ isOpen, close }: ModalProps) => {
             onRequestClose={close}
             contentLabel="Election Participation Modal - Confirming Participation"
             preventScroll
-            shouldCloseOnOverlayClick={!isLoading}
-            shouldCloseOnEsc={!isLoading}
+            shouldCloseOnOverlayClick={
+                step !== ParticipationStep.ConfirmPassword
+            }
+            shouldCloseOnEsc={step !== ParticipationStep.ConfirmPassword}
         >
             {step === ParticipationStep.ConfirmParticipation && (
                 <ConfirmParticipationStep
@@ -262,7 +270,7 @@ const ConfirmParticipationStep = ({
                     Not showing up could impact your standing and reputation in
                     the community. If for some reason you cannot participate in
                     the election, please update your status more than 24 hours
-                    from the election.
+                    prior to the start of the election.
                 </Text>
                 <div className="p-3 border rounded">
                     <Form.Checkbox

--- a/packages/webapp/src/elections/utils.ts
+++ b/packages/webapp/src/elections/utils.ts
@@ -3,10 +3,10 @@ import dayjs from "dayjs";
 import { VoteData } from "elections/interfaces";
 
 export const extractElectionDates = (election: any) => {
-    const rawStartDateTime = `${
-        (election?.election_seeder && election.election_seeder.end_time) ||
-        election?.start_time
-    }Z`;
+    const rawStartDateTime =
+        (election?.election_seeder?.end_time ||
+            election?.start_time ||
+            election?.seed?.start_time) + "Z";
 
     if (!rawStartDateTime) {
         throw new Error("Error parsing the Election start date.");

--- a/packages/webapp/src/elections/utils.ts
+++ b/packages/webapp/src/elections/utils.ts
@@ -6,7 +6,7 @@ export const extractElectionDates = (election: any) => {
     const rawStartDateTime =
         (election?.election_seeder?.end_time ||
             election?.start_time ||
-            election?.seed?.start_time) + "Z";
+            election?.seed?.end_time) + "Z";
 
     if (!rawStartDateTime) {
         throw new Error("Error parsing the Election start date.");

--- a/packages/webapp/src/encryption/components/new-password-form.tsx
+++ b/packages/webapp/src/encryption/components/new-password-form.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { PrivateKey } from "eosjs/dist/eosjs-key-conversions";
+import { IoMdCopy } from "react-icons/io";
 
 import {
     Button,
@@ -17,7 +18,7 @@ interface Props {
 }
 
 export const NewPasswordForm = ({ isLoading, onSubmit, onCancel }: Props) => {
-    const [copyText, setCopyText] = useState("Copy");
+    const [didCopyText, setDidCopyText] = useState<boolean>(false);
     const [fields, setFields] = useFormFields({
         password: generateEncryptionKey().privateKey.toLegacyString(),
         passwordConfirmation: "",
@@ -46,33 +47,44 @@ export const NewPasswordForm = ({ isLoading, onSubmit, onCancel }: Props) => {
 
     const copyPassword = () => {
         navigator.clipboard.writeText(fields.password);
-        setCopyText("Copied!");
+        setDidCopyText(true);
     };
 
     return (
         <div className="space-y-4">
             <Text>
                 It looks like you don’t have a password set to participate in
-                the election. Please copy your password and confirm it here.
+                the election. Please copy and save your password somewhere safe,
+                and confirm it below.
             </Text>
-            <Text>Copy Password</Text>
             <form onSubmit={doSubmit} className="space-y-3">
                 <Form.LabeledSet
                     label="Your Election Password"
                     htmlFor="password"
                     className="col-span-6 sm:col-span-3"
                 >
-                    <Form.Input
-                        id="password"
-                        type="text"
-                        disabled
-                        required
-                        value={fields.password}
-                        onChange={onChangeFields}
-                    />
-                    <Button onClick={copyPassword}>{copyText}</Button>
+                    <div className="flex space-x-2">
+                        <Form.Input
+                            id="password"
+                            type="text"
+                            disabled
+                            required
+                            value={fields.password}
+                            onChange={onChangeFields}
+                        />
+                        <Button onClick={copyPassword}>
+                            {didCopyText ? (
+                                "Copied!"
+                            ) : (
+                                <IoMdCopy
+                                    color="white"
+                                    size={22}
+                                    className="-mx-2"
+                                />
+                            )}
+                        </Button>
+                    </div>
                 </Form.LabeledSet>
-                <Text>Please paste your password below.</Text>
                 <Form.LabeledSet
                     label="Confirm Your Election Password"
                     htmlFor="passwordConfirmation"

--- a/packages/webapp/src/pages/election/index.tsx
+++ b/packages/webapp/src/pages/election/index.tsx
@@ -1,24 +1,38 @@
 import { FluidLayout, useCurrentElection } from "_app";
-import { Container, Heading } from "_app/ui";
+import { Container, Heading, Loader } from "_app/ui";
 import { OngoingElection, RegistrationElection } from "elections";
 import { ElectionStatus } from "elections/interfaces";
 import { EncryptionPasswordAlert } from "encryption";
 
 export const ElectionPage = () => {
-    const { data: currentElection } = useCurrentElection();
+    const { data: currentElection, isLoading } = useCurrentElection();
 
-    // TODO: Enum for election states?
     return (
         <FluidLayout
             title="Election"
-            banner={<EncryptionPasswordAlert promptSetupEncryptionKey />}
+            banner={
+                <EncryptionPasswordAlert
+                    promptSetupEncryptionKey={
+                        currentElection?.electionState !==
+                        ElectionStatus.Registration
+                    }
+                />
+            }
         >
-            <div className="divide-y">
+            {isLoading ? (
                 <Container>
-                    <Heading size={1}>Election</Heading>
+                    <Loader />
                 </Container>
-                <ElectionBody electionState={currentElection?.electionState} />
-            </div>
+            ) : (
+                <div className="divide-y">
+                    <Container>
+                        <Heading size={1}>Election</Heading>
+                    </Container>
+                    <ElectionBody
+                        electionState={currentElection?.electionState}
+                    />
+                </div>
+            )}
         </FluidLayout>
     );
 };

--- a/packages/webapp/src/pages/election/index.tsx
+++ b/packages/webapp/src/pages/election/index.tsx
@@ -40,6 +40,7 @@ export const ElectionPage = () => {
 const ElectionBody = ({ electionState }: { electionState?: string }) => {
     switch (electionState) {
         case ElectionStatus.Registration:
+        case ElectionStatus.Seeding:
             return <RegistrationElection />;
         case ElectionStatus.Active:
         case ElectionStatus.Final: // TODO: This is one state where there's a board but no satoshi. UI should reflect that.
@@ -47,7 +48,7 @@ const ElectionBody = ({ electionState }: { electionState?: string }) => {
         default:
             return (
                 <Container>
-                    <Heading size={2}>Unhandled state</Heading>
+                    <Heading size={2}>Processing election</Heading>
                 </Container>
             );
     }


### PR DESCRIPTION
## In This PR
- Handle pre-election state transitions, including automating transition of UI into the `Active` state of the election.
- Adjust UI and add niceties, such as countdown timer.
- Factor our `useCountdown` hook. Callback from that hook triggers polling for updates to election state. That polling stops when election enters `Active` state.
- Prevent accidental dismissal of registration modal when on the password creation/confirmation screen.
- Add timezone codes to times.
- Add delay after opting in/out so that blockchain has time to catch up before updating UI.
- Style up copy button on password form.