### PR TITLE
Completes zoom request meeting link flow for elections

### DIFF
--- a/packages/webapp/src/_api/zoom-commons.ts
+++ b/packages/webapp/src/_api/zoom-commons.ts
@@ -53,7 +53,15 @@ export const zoomRefreshAuth = async (refreshToken: string) => {
 };
 
 export const zoomAccountJWTIsExpired = (zoomAccountJWT: ZoomAccountJWT) => {
-    return false; // TODO: fix and calculate it properly
+    const accessTokenEncodedData = zoomAccountJWT.access_token.split(".");
+    if (accessTokenEncodedData.length !== 3)
+        throw new Error("invalid zoom jwt payload");
+
+    const accessTokenData = JSON.parse(atob(accessTokenEncodedData[1]));
+    if (!accessTokenData.exp) {
+        throw new Error("can't parse zoom jwt expiration date");
+    }
+    return Date.now() > accessTokenData.exp * 1000;
 };
 
 export const zoomResponseIsInvalidAccess = (response: any) => {

--- a/packages/webapp/src/elections/api/fixtures.ts
+++ b/packages/webapp/src/elections/api/fixtures.ts
@@ -46,14 +46,14 @@ export const fixtureRegistrationElection: CurrentElection = {
 // In the grand scheme of other fixture data,
 // this would represent the Round 1 election, where there were 5 people in 2 groups
 export const fixtureCurrentElection: CurrentElection = {
-    electionState: "active",
+    electionState: "current_election_state_active",
     config: {
         num_participants: 13,
         num_groups: 7,
     },
     round: 2,
     saved_seed: "some seed",
-    round_end: "2021-08-04T18:34:45.000",
+    round_end: "2021-08-15T18:34:45.000",
 };
 
 // This data represents the *in-progress*, *first* round (whereas other fixture data represents the *results* of the overall election)

--- a/packages/webapp/src/elections/api/fixtures.ts
+++ b/packages/webapp/src/elections/api/fixtures.ts
@@ -46,7 +46,7 @@ export const fixtureRegistrationElection: CurrentElection = {
 // In the grand scheme of other fixture data,
 // this would represent the Round 1 election, where there were 5 people in 2 groups
 export const fixtureCurrentElection: CurrentElection = {
-    electionState: "current_election_state_active",
+    electionState: ElectionStatus.Active,
     config: {
         num_participants: 13,
         num_groups: 7,

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useQueryClient } from "react-query";
 import { Flipper, Flipped } from "react-flip-toolkit";
-import { BiCheck, BiWebcam } from "react-icons/bi";
+import { BiCheck } from "react-icons/bi";
 import { RiVideoUploadLine } from "react-icons/ri";
 
 import { useUALAccount } from "_app";
@@ -22,6 +22,7 @@ import { setVote } from "../../transactions";
 import Consensometer from "./consensometer";
 import PasswordPromptModal from "./password-prompt-modal";
 import RoundHeader from "./round-header";
+import { RequestElectionMeetingLinkButton } from "./request-election-meeting-link-button";
 
 export interface RoundSegmentProps {
     electionState: string;
@@ -41,10 +42,6 @@ export const OngoingRoundSegment = ({
 
     const [selectedMember, setSelected] = useState<MemberData | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [
-        showZoomLinkPermutations,
-        setShowZoomLinkPermutations,
-    ] = useState<boolean>(false); // TODO: Replace with real meeting link functionality
     const [showPasswordPrompt, setShowPasswordPrompt] = useState<boolean>(
         false
     ); // TODO: Hook up to the real password prompt
@@ -139,66 +136,7 @@ export const OngoingRoundSegment = ({
                     Meet with your group. Align on a leader &gt;2/3 majority.
                     Select your leader and submit your vote below.
                 </Text>
-                {!showZoomLinkPermutations ? (
-                    <Button
-                        size="sm"
-                        onClick={() => setShowZoomLinkPermutations(true)}
-                    >
-                        <BiWebcam className="mr-1" />
-                        Request meeting link
-                    </Button>
-                ) : (
-                    <>
-                        <div className="flex items-center space-x-2">
-                            <Button size="sm">
-                                <BiWebcam className="mr-1" />
-                                Request meeting link
-                            </Button>
-                            <Text
-                                size="xs"
-                                type="note"
-                                className="leading-tight"
-                            >
-                                [Not implemented] No one has created
-                                <br />a link yet. Should trigger Zoom Oauth.
-                            </Text>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                            <Button
-                                size="sm"
-                                onClick={() => setShowPasswordPrompt(true)}
-                            >
-                                <BiWebcam className="mr-1" />
-                                Request meeting link
-                            </Button>
-                            <Text
-                                size="xs"
-                                type="note"
-                                className="leading-tight"
-                            >
-                                [Opens modal UI] Link created,
-                                <br />
-                                but password not set in browser.
-                            </Text>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                            <Button size="sm">
-                                <BiWebcam className="mr-1" />
-                                Join meeting
-                            </Button>
-                            <Text
-                                size="xs"
-                                type="note"
-                                className="leading-tight"
-                            >
-                                [Not implemented] Poll for encrypted link. If
-                                found
-                                <br />
-                                automatically decrypt and show join button.
-                            </Text>
-                        </div>
-                    </>
-                )}
+                <RequestElectionMeetingLinkButton />
             </Container>
             <Container className="flex justify-between">
                 <Heading size={4} className="inline-block">

--- a/packages/webapp/src/elections/components/ongoing-election-components/request-election-meeting-link-button.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/request-election-meeting-link-button.tsx
@@ -100,7 +100,7 @@ export const RequestElectionMeetingLinkButton = () => {
             const signedTrx = await ualAccount.signTransaction(transaction, {
                 broadcast: true,
             });
-            console.info("inductmeetin trx", signedTrx);
+            console.info("electmeeting trx", signedTrx);
 
             // todo: refetch the round data to set the new defined roundMeetingLink
         } catch (error) {

--- a/packages/webapp/src/elections/transactions.ts
+++ b/packages/webapp/src/elections/transactions.ts
@@ -3,7 +3,7 @@ import { EncryptedKey } from "encryption";
 
 export const setElectionMeeting = (
     authorizerAccount: string,
-    id: number,
+    round: number,
     keys: EncryptedKey[],
     data: Uint8Array,
     old_data?: Uint8Array
@@ -11,7 +11,7 @@ export const setElectionMeeting = (
     actions: [
         {
             account: edenContractAccount,
-            name: "inductmeetin",
+            name: "electmeeting",
             authorization: [
                 {
                     actor: authorizerAccount,
@@ -20,7 +20,7 @@ export const setElectionMeeting = (
             ],
             data: {
                 account: authorizerAccount,
-                id,
+                round,
                 keys,
                 data,
                 old_data,

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -37,6 +37,8 @@ export const fixtureEdenMembers: EdenMember[] = [
             ElectionParticipationStatus.NotInElection,
         election_rank: 2,
         representative: "egeon.edev",
+        encryption_key: "EOS7vz6S1LVdztSk7fViBzD2LP2TPvED5K49iDQskSzJ42i75Kg19",
+        // pk for above key is: 5J5JPLn1bcidJp9BLekYWdtAk6CJGG8cfGhSoJ5nibVk4dHrSeJ
     },
     {
         name: "Eden Member 11",
@@ -99,6 +101,8 @@ export const fixtureEdenMembers: EdenMember[] = [
             ElectionParticipationStatus.NotInElection,
         election_rank: 1,
         representative: "pip.edev",
+        encryption_key: "EOS8S8oAAT5oa2idwX6e1ZDThQgzRTeXNZ2vpQfnCpxo5Z9sSamYg",
+        // pk for above key is: 5JN3VWDFMRn9RexLZJKvA82we6yXweDGHUzStqJA4WuktpEjHbF
     },
     {
         name: "Eden Member 22",

--- a/packages/webapp/src/pages/oauth/zoom.tsx
+++ b/packages/webapp/src/pages/oauth/zoom.tsx
@@ -63,20 +63,15 @@ export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
 
     useEffect(() => {
         if (newZoomAccountJWT) {
-            console.info("setting zoom jwt", newZoomAccountJWT);
             setZoomAccountJWT(newZoomAccountJWT);
 
             if (oauthState === "request-election-link") {
-                router.push("/election");
                 setRedirectMessage(
                     "Thanks for linking your Zoom Account. Redirecting back to your Election page..."
                 );
+                router.push("/election");
             }
         }
-
-        return () => {
-            console.info("whatevs");
-        };
     }, []);
 
     return (


### PR DESCRIPTION
First time on election page if the meeting link is not generated and you didn't link your zoom account yet:
![image](https://user-images.githubusercontent.com/79721020/129371616-2c354413-610c-4da1-a968-440e5125c2f3.png)
---

Redirecting message, keeping your election state:
![image](https://user-images.githubusercontent.com/79721020/129371856-537b4e97-9c63-47e7-8c80-e291b61061bb.png)
---

When redirected to the election page again (or whenever you access your election page but you linked your zoom account already):
![image](https://user-images.githubusercontent.com/79721020/129371420-2d387d11-c377-47b2-976a-725dbbf115ab.png)
---

If the link is already generated by you or any other member in your round group:
![image](https://user-images.githubusercontent.com/79721020/129372034-abfddbcd-deda-487c-8974-799f8d5b3a44.png)
---

(I feel like the join meeting could be in another color, like orange...)