### PR TITLE
Redirect to My Delegation when election completes

### DIFF
--- a/packages/webapp/src/_app/config.ts
+++ b/packages/webapp/src/_app/config.ts
@@ -2,9 +2,9 @@ export const ROUTES: any = {
     HOME: { href: "/", label: "Home" },
     MEMBERS: { href: "/members", label: "Community" },
     INDUCTION: { href: "/induction", label: "Membership" },
-    REPRESENTATION: {
-        href: "/representation",
-        label: "Representation",
+    DELEGATION: {
+        href: "/delegates",
+        label: "My Delegation",
         hideNav: true,
     },
     TREASURY: { href: "/treasury", label: "Treasury", hideNav: true },

--- a/packages/webapp/src/_app/hooks/utils.ts
+++ b/packages/webapp/src/_app/hooks/utils.ts
@@ -84,3 +84,12 @@ export const useCountdown = ({
         )}:${padTime(secRemaining)}`,
     };
 };
+
+// This gives us the ability to check prevProps
+export const usePrevious = <T>(value: T): T => {
+    const ref: any = useRef<T>();
+    useEffect(() => {
+        ref.current = value;
+    }, [value]);
+    return ref.current;
+};

--- a/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
@@ -101,6 +101,7 @@ export const ChiefsRoundSegment = ({ roundEndTime }: RoundSegmentProps) => {
             <MembersGrid members={members}>
                 {(member) => (
                     <DelegateChip
+                        key={`${member.account}-chief-delegate`}
                         member={member}
                         delegateTitle="Elected Chief Delegate"
                     />

--- a/packages/webapp/src/pages/election/index.tsx
+++ b/packages/webapp/src/pages/election/index.tsx
@@ -1,4 +1,8 @@
-import { FluidLayout, useCurrentElection } from "_app";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+
+import { FluidLayout, useCurrentElection, usePrevious } from "_app";
+import { ROUTES } from "_app/config";
 import { Container, Heading, Loader } from "_app/ui";
 import {
     ErrorLoadingElection,
@@ -9,7 +13,18 @@ import { ElectionStatus } from "elections/interfaces";
 import { EncryptionPasswordAlert } from "encryption";
 
 export const ElectionPage = () => {
+    const router = useRouter();
+    const [isElectionComplete, setIsElectionComplete] = useState(false);
     const { data: currentElection, isLoading, isError } = useCurrentElection();
+    const prevElectionState = usePrevious(currentElection?.electionState);
+
+    useEffect(() => {
+        if (prevElectionState !== ElectionStatus.Final) return;
+        if (currentElection?.electionState === ElectionStatus.Registration) {
+            setIsElectionComplete(true);
+            router.push(ROUTES.DELEGATION.href);
+        }
+    }, [currentElection]);
 
     if (isError) return <ErrorLoadingElection />;
 
@@ -25,7 +40,7 @@ export const ElectionPage = () => {
                 />
             }
         >
-            {isLoading ? (
+            {isLoading || isElectionComplete ? (
                 <LoaderSection />
             ) : (
                 <div className="divide-y">


### PR DESCRIPTION
I was going to wait on this, but during my demo this morning, it was clear that work was going to be needed for the state transition from the end of the election to the participation stage anyway (it was still showing the old OPTED IN state). Since we really want to show people the final results of the election anyway and redirect them to the My Delegation page, it made since to go ahead and do just that.