### PR TITLE
Update UI in reaction to contract globals election round time changes.

### DIFF
--- a/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/round-header.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-import dayjs, { Dayjs } from "dayjs";
 import { FaCheckCircle } from "react-icons/fa";
 import { GoSync } from "react-icons/go";
 

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -42,8 +42,7 @@ export const OngoingElection = ({ election }: { election: any }) => {
         return <ErrorLoadingElection />;
     }
 
-    const { election_round_time_sec, election_break_time_sec } = globals;
-    const roundDurationSec = election_round_time_sec + election_break_time_sec;
+    const roundDurationSec = globals.election_round_time_sec;
     const roundDurationMs = roundDurationSec * 1000;
     const roundIndex = election.round ?? memberStats.ranks.length;
     const roundEndTimeRaw = election.round_end ?? election.seed.end_time;


### PR DESCRIPTION
Recent commit removed `election_break_time_sec` from the contract tables. This fixes the breaking UI change that caused.

Note: Once merged, our test contracts will need to be updated to calculate times properly. 