### PR TITLE
Add premeeting and failed decryption info

### DIFF
--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round-segment.tsx
@@ -230,6 +230,7 @@ export const OngoingRoundSegment = ({
                     stage
                 ) && (
                     <RequestElectionMeetingLinkButton
+                        stage={stage}
                         roundIndex={roundIndex}
                         meetingStartTime={meetingStartTime}
                         meetingDurationMs={meetingDurationMs}

--- a/packages/webapp/src/elections/components/ongoing-election-components/request-election-meeting-link-button.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/request-election-meeting-link-button.tsx
@@ -157,8 +157,6 @@ const JoinMeetingButton = ({
     stage,
     encryptedData,
 }: JoinMeetingButtonProps) => {
-    console.info(stage);
-
     const [roundMeetingLink, setRoundMeetingLink] = useState("");
     const [
         failedToDecryptMeetingLink,
@@ -206,8 +204,9 @@ const JoinMeetingButton = ({
                 <BsExclamationTriangle className="mr-1 mb-px" />
             </Text>
             <Text type="danger">
-                Failed to retrieve the meeting link. Please reach out to someone
-                from your election round group or access the support.
+                Failed to retrieve meeting link. Ask someone else in your 
+                election round group for the link or join the community 
+                support room above.
             </Text>
         </div>
     ) : stage === RoundStage.PreMeeting ? (


### PR DESCRIPTION
- Extracts the join button and adds the stage flow in there (premeeting and meeting)
- When the zoom link is existent and it fails to decrypt it, displays an informational message: 
  > Failed to retrieve the meeting link. Please reach out to someone from your election round group or access the support.
- While the meeting does not start it shows the message: 
  > Waiting for meeting to start to display the join button.