### PR TITLE
Ensure completed rounds appear after new rounds complete

### DIFF
--- a/packages/webapp/src/_app/eos/api.ts
+++ b/packages/webapp/src/_app/eos/api.ts
@@ -98,6 +98,8 @@ export const getTableRawRows = async <T = any>(
         show_payer: false,
         table: table,
         ...options,
+        lower_bound: options.lowerBound,
+        upper_bound: options.upperBound,
     };
 
     const response = await fetch(RPC_GET_TABLE_ROWS, {

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -279,7 +279,7 @@ export const useMyDelegation = (queryOptions: any = {}) => {
 
     return useQuery({
         ...queryMyDelegation(memberStats, member?.account),
-        enabled: enabled && Boolean(member?.account),
+        enabled: enabled && Boolean(member?.account && memberStats),
     });
 };
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -281,7 +281,7 @@ export const useMyDelegation = ({
 }: {
     memberStats?: MemberStats;
     queryOptions?: any;
-}) => {
+} = {}) => {
     const { data: member } = useCurrentMember();
     const { data: cachedMemberStats } = useMemberStats({
         enabled: !memberStats,

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -453,14 +453,11 @@ export const useOngoingElectionData = (
     );
 
     let enabled = Boolean(loggedInMember && electionState && myDelegation);
-    if ("enabled" in queryOptions) {
-        enabled = enabled && queryOptions.enabled;
-    }
 
     return useQuery<Election, Error>({
         queryKey,
         queryFn,
-        enabled,
         ...queryOptions,
+        enabled: enabled && (queryOptions.enabled ?? true),
     });
 };

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -12,8 +12,6 @@ import {
     MemberStats,
 } from "members";
 import { getCommunityGlobals } from "_app/api";
-
-import { useUALAccount } from "../eos";
 import {
     getCurrentInductions,
     getEndorsementsByInductionId,
@@ -38,13 +36,13 @@ import {
 import {
     ActiveStateConfigType,
     CurrentElection,
-    CurrentElection_activeState,
     Election,
-    ElectionStatus,
     VoteData,
 } from "elections/interfaces";
 import { EncryptionScope, getEncryptedData } from "encryption/api";
 import { TableQueryOptions } from "_app/eos/interfaces";
+
+import { useUALAccount } from "../eos";
 
 export const queryHeadDelegate = {
     queryKey: "query_head_delegate",

--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -1,12 +1,9 @@
-import { CurrentElection } from "elections/interfaces";
-import { EdenMember, MemberStats } from "members";
+import { EdenMember } from "members";
 import { queryClient } from "pages/_app";
 import {
     isValidDelegate,
-    queryCurrentElection,
     queryElectionState,
     queryMemberByAccountName,
-    queryMembersStats,
     queryVoteDataRow,
 } from "_app";
 

--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -36,18 +36,12 @@ const getMemberWrapper = async (account: string) => {
 };
 
 export const getMyDelegation = async (
-    loggedInMemberAccount: string | undefined
+    loggedInMemberAccount?: string,
+    memberStats?: MemberStats
 ): Promise<EdenMember[]> => {
-    const currentElection: CurrentElection = await queryClient.fetchQuery(
-        queryCurrentElection
-    );
-    const memberStats: MemberStats = await queryClient.fetchQuery(
-        queryMembersStats
-    );
-
     let myDelegates: EdenMember[] = [];
 
-    if (!loggedInMemberAccount) return myDelegates;
+    if (!loggedInMemberAccount || !memberStats) return myDelegates;
 
     let nextMemberAccount = loggedInMemberAccount;
     let isHeadChief: Boolean;

--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -37,11 +37,12 @@ const getMemberWrapper = async (account: string) => {
 
 export const getMyDelegation = async (
     loggedInMemberAccount?: string,
-    memberStats?: MemberStats
+    highestCompletedRoundIndex?: number
 ): Promise<EdenMember[]> => {
     let myDelegates: EdenMember[] = [];
 
-    if (!loggedInMemberAccount || !memberStats) return myDelegates;
+    if (!loggedInMemberAccount || highestCompletedRoundIndex === undefined)
+        return myDelegates;
 
     let nextMemberAccount = loggedInMemberAccount;
     let isHeadChief: Boolean;
@@ -58,8 +59,6 @@ export const getMyDelegation = async (
 
         // Fill the array from next available position up to member.election_rank with member,
         // in case this delegate got voted up through multiple levels
-        const highestCompletedRoundIndex = memberStats.ranks.length - 1;
-
         for (
             let idx = myDelegates.length;
             idx <= memberRankIndex && idx <= highestCompletedRoundIndex;

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -19,13 +19,11 @@ import {
 
 import * as Ongoing from "./ongoing-election-components";
 import { useEffect, useState } from "react";
-import { useQueryClient } from "react-query";
 
 // TODO: Non-participating-eden-member currently sees error.
 // TODO: Specifically, what happens to CompletedRound component when non-participating-eden-member logs in?
 // TODO: Make sure time zone changes during election are handled properly
 export const OngoingElection = ({ election }: { election: any }) => {
-    const queryClient = useQueryClient();
     const [awaitingNextRound, setAwaitingNextRound] = useState(false);
     const {
         data: globals,
@@ -37,17 +35,14 @@ export const OngoingElection = ({ election }: { election: any }) => {
         isLoading: isLoadingMemberStats,
         isError: isErrorMemberStats,
     } = useMemberStats();
-    const { data: ongoingElectionData } = useOngoingElectionData();
+    const { data: ongoingElectionData } = useOngoingElectionData(election);
 
     useEffect(() => {
         if (!awaitingNextRound) return;
-        // trigger recalc of rounds count for election state
-        // TODO: Investigate why we need this further; or obviate it via refactor
-        queryClient.invalidateQueries("query_member_stats");
         setAwaitingNextRound(false);
     }, [election.round]);
 
-    // TODO: Poll the memberStats query above instead?
+    // Poll for updated election information while awaitingNextRound
     useCurrentElection({
         enabled: awaitingNextRound,
         refetchInterval: 5000,

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -34,6 +34,10 @@ export const OngoingElection = ({ election }: { election: any }) => {
     } = useMemberStats();
     const { data: ongoingElectionData } = useOngoingElectionData();
 
+    console.log("%<OngoingElection>:", "background: light-blue;");
+    console.log("ongoingElectionData:", ongoingElectionData);
+    console.log("%</OngoingElection>:", "background: light-blue; color: red");
+
     if (isLoadingGlobals || isLoadingMemberStats) {
         return (
             <Container>

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -34,8 +34,9 @@ export const DelegatesPage = (props: Props) => {
         currentElection?.electionState !== ElectionStatus.Registration;
 
     const { data: myDelegation } = useMyDelegation({
-        enabled: !isElectionInProgress,
+        queryOptions: { enabled: !isElectionInProgress },
     });
+
     const { data: electionState } = useElectionState();
 
     const { data: myDelegationMemberData } = useMemberDataFromEdenMembers(


### PR DESCRIPTION
I'll squash this before I merge.

This basically ensures that all internal dependency queries inside of the `useOngoingElectionData()` query hook refetch when the current election object updates.

There are a few other mostly-related, minor tweaks herein as well.