### PR TITLE
Fix: getting my delegation can result in infinite loop

### DIFF
--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -43,6 +43,7 @@ export const getMyDelegation = async (
 
     let nextMemberAccount = loggedInMemberAccount;
     let isHeadChief: Boolean;
+    let currRound = highestCompletedRoundIndex + 1;
     do {
         let member = await getMemberWrapper(nextMemberAccount);
         if (!member)
@@ -65,7 +66,8 @@ export const getMyDelegation = async (
         }
         isHeadChief = member.account === member.representative;
         nextMemberAccount = member.representative;
-    } while (isValidDelegate(nextMemberAccount) && !isHeadChief);
+        currRound -= 1;
+    } while (currRound && isValidDelegate(nextMemberAccount) && !isHeadChief);
 
     return myDelegates;
 };

--- a/packages/webapp/src/delegates/api/eden-contract.ts
+++ b/packages/webapp/src/delegates/api/eden-contract.ts
@@ -63,10 +63,10 @@ export const getMyDelegation = async (
             idx++
         ) {
             myDelegates.push(member);
+            currRound -= 1;
         }
         isHeadChief = member.account === member.representative;
         nextMemberAccount = member.representative;
-        currRound -= 1;
     } while (currRound && isValidDelegate(nextMemberAccount) && !isHeadChief);
 
     return myDelegates;


### PR DESCRIPTION
I just ran an election that uncovered this bug. Here's the setting:

- Election in Round 2
- `edenmember12` is delegate participating in Round 2
- `edenmember12` was represented previously by `edenmember11` and so `edenmember11` is the value for `representative` in the `member` table entry for `edenmember12`
- `edenmember11` participated in the current election's Round 1 with `edenmember12`.
- `getMyDelegation` looks for `edenmember12`'s R1 participants, finds `edenmember11`. Then looks at `edenmember11`'s delegate, finds `edenmember12`...and so on.

This fix ensures that the loop will stop after completing for all the rounds.
