### PR TITLE
Ongoing election UI for non-participating Eden members

### DIFF
--- a/packages/webapp/src/_app/api/eden-contract.ts
+++ b/packages/webapp/src/_app/api/eden-contract.ts
@@ -1,5 +1,6 @@
 import { EdenMember } from "members";
 import { CONTRACT_GLOBAL_TABLE, getTableRows } from "_app";
+import { ElectionParticipationStatus } from "./interfaces";
 
 // check that member has participated in an election (if there's been one yet) (!="zzz...") and came to consensus with their group in the last election (!=0)
 const MEMBER_REPRESENTATIVE_IF_NOT_PARTICIPATED_IN_RECENT_ELECTION =
@@ -29,6 +30,22 @@ export const isValidDelegate = (memberRep?: string) =>
     memberRep !==
         MEMBER_REPRESENTATIVE_IF_NOT_PARTICIPATED_IN_RECENT_ELECTION &&
     !isResultFromNoConsensus(memberRep);
+
+/**
+ * This will tell you, during an election, if the member you pass in is not
+ * participating and did not participate at all in the current, ongoing election
+ * (i.e., never opted in to participate.) We first check whether their representative
+ * field value is the magic value for a member who has never completed an election,
+ * and then we check to make sure their participation status is 0 (NotInElection) to
+ * differentiate them from first-time participants in the current ongoing election.
+ * @param {EdenMember} member - The member you're checking
+ * @returns {boolean}
+ */
+export const isNonParticipantInOngoingElection = (member: EdenMember) =>
+    member.representative ===
+        MEMBER_REPRESENTATIVE_IF_NOT_PARTICIPATED_IN_RECENT_ELECTION &&
+    member.election_participation_status ===
+        ElectionParticipationStatus.NotInElection;
 
 export const getCommunityGlobals = async () => {
     const rows = await getTableRows(CONTRACT_GLOBAL_TABLE, {

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -150,19 +150,22 @@ export const queryCommunityGlobals = {
 export const queryOngoingElectionData = (
     votingMemberData?: MemberData[],
     currentElection?: CurrentElection,
-    myDelegation?: EdenMember[]
+    myDelegation?: EdenMember[],
+    currentMember?: EdenMember
 ) => ({
     queryKey: [
         "query_ongoing_round",
         votingMemberData,
         currentElection,
         myDelegation,
+        currentMember,
     ],
     queryFn: () => {
         return getOngoingElectionData(
             votingMemberData,
             currentElection,
-            myDelegation
+            myDelegation,
+            currentMember
         );
     },
 });
@@ -458,7 +461,8 @@ export const useOngoingElectionData = ({
         ...queryOngoingElectionData(
             votingMemberData.data,
             currentElection,
-            myDelegation.data
+            myDelegation.data,
+            currentMember.data
         ),
         ...queryOptions,
         enabled: enabled && (queryOptions.enabled ?? true),

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -15,6 +15,7 @@ import {
     getTableRows,
     INDEX_MEMBER_BY_REP,
     INDEX_VOTE_BY_GROUP_INDEX,
+    isNonParticipantInOngoingElection,
     isValidDelegate,
     queryMemberByAccountName,
     queryMembers,
@@ -353,7 +354,8 @@ const getParticipantsOfCompletedRounds = async (myDelegation: EdenMember[]) => {
 export const getOngoingElectionData = async (
     votingMemberData: MemberData[] = [],
     currentElection?: CurrentElection,
-    myDelegation: EdenMember[] = []
+    myDelegation: EdenMember[] = [],
+    loggedInMember?: EdenMember
 ) => {
     const isElectionOngoing =
         currentElection?.electionState === ElectionStatus.Active ||
@@ -369,10 +371,15 @@ export const getOngoingElectionData = async (
         myDelegation
     );
 
+    const isMemberOptedOut = loggedInMember
+        ? isNonParticipantInOngoingElection(loggedInMember)
+        : undefined;
+
     const electionData = {
         ...ELECTION_DEFAULTS,
         isElectionOngoing,
         isMemberStillParticipating,
+        isMemberOptedOut,
         inSortitionRound,
         completedRounds,
         ongoingRound,

--- a/packages/webapp/src/elections/components/ongoing-election.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election.tsx
@@ -19,8 +19,6 @@ import {
 import * as Ongoing from "./ongoing-election-components";
 import { useEffect, useState } from "react";
 
-// TODO: Non-participating-eden-member currently sees error.
-// TODO: Specifically, what happens to CompletedRound component when non-participating-eden-member logs in?
 // TODO: Make sure time zone changes during election are handled properly
 export const OngoingElection = ({ election }: { election: any }) => {
     const [awaitingNextRound, setAwaitingNextRound] = useState(false);
@@ -62,7 +60,6 @@ export const OngoingElection = ({ election }: { election: any }) => {
         return <ErrorLoadingElection />;
     }
 
-    const numCompletedRounds = ongoingElectionData?.completedRounds?.length;
     const roundDurationSec = globals.election_round_time_sec;
     const roundDurationMs = roundDurationSec * 1000;
     const roundEndTimeRaw = election.round_end ?? election.seed.end_time;
@@ -77,7 +74,7 @@ export const OngoingElection = ({ election }: { election: any }) => {
             </Container>
             <Ongoing.SupportSegment />
 
-            <CompletedRounds numCompletedRounds={numCompletedRounds} />
+            <CompletedRounds ongoingElectionData={ongoingElectionData} />
             <SignInContainer />
             <SignUpContainer />
             <NoParticipationInFurtherRoundsMessage
@@ -107,6 +104,11 @@ const NoParticipationInFurtherRoundsMessage = ({
     if (ongoingElectionData.isMemberStillParticipating) {
         return null;
     }
+
+    let statusText = "You are not involved in further rounds.";
+    if (ongoingElectionData.isMemberOptedOut)
+        statusText = "You are not participating in this election.";
+
     return (
         <Container className="flex items-center space-x-2 pr-8 py-8">
             <BsInfoCircle
@@ -115,7 +117,7 @@ const NoParticipationInFurtherRoundsMessage = ({
             />
             <div className="flex-1">
                 <Text size="sm">
-                    You are not involved in further rounds. Please{" "}
+                    {statusText} Please{" "}
                     <Link href={""}>join the Community Room</Link> &amp; Support
                     for news and updates of the ongoing election. The results
                     will be displayed in the{" "}
@@ -132,12 +134,20 @@ const NoParticipationInFurtherRoundsMessage = ({
 export default OngoingElection;
 
 interface CompletedRoundsProps {
-    numCompletedRounds?: number;
+    ongoingElectionData?: Election;
 }
 
-const CompletedRounds = ({ numCompletedRounds }: CompletedRoundsProps) => {
+const CompletedRounds = ({ ongoingElectionData }: CompletedRoundsProps) => {
     const { data: currentMember } = useCurrentMember();
-    if (!currentMember || !numCompletedRounds) return null;
+    const numCompletedRounds = ongoingElectionData?.completedRounds?.length;
+
+    if (
+        !currentMember ||
+        ongoingElectionData?.isMemberOptedOut ||
+        !numCompletedRounds
+    )
+        return null;
+
     return (
         <>
             {[...Array(numCompletedRounds)].map((_, i) => {

--- a/packages/webapp/src/elections/interfaces.ts
+++ b/packages/webapp/src/elections/interfaces.ts
@@ -110,6 +110,7 @@ interface ElectionCompletedRound {
 export interface Election {
     isElectionOngoing?: boolean;
     isMemberStillParticipating?: boolean;
+    isMemberOptedOut?: boolean;
     inSortitionRound?: boolean;
     // .length === number of rounds that have completed (regardless of current member's participation)
     completedRounds: ElectionCompletedRound[];


### PR DESCRIPTION
* Adds an `isMemberOptedOut` property to `Election`s.
* Adjust non-participating messaging and hides "completed round" display attempts from those who were never opted into the election.

![image](https://user-images.githubusercontent.com/7911424/130523902-87126f1e-fd06-4426-a49d-dd925a997740.png)
