### PR TITLE
Add token balance and history button in profile

### DIFF
--- a/packages/webapp/src/_app/api/eosio.token-contract.ts
+++ b/packages/webapp/src/_app/api/eosio.token-contract.ts
@@ -1,0 +1,21 @@
+import { minimumDonationAmount } from "config";
+import { Asset, assetFromString } from "_app/utils";
+import { eosJsonRpc } from "../eos";
+
+export const getTokenBalanceForAccount = async (
+    account: string
+): Promise<Asset> => {
+    const data = await eosJsonRpc.get_currency_balance(
+        "eosio.token",
+        account,
+        minimumDonationAmount.symbol
+    );
+
+    console.info("eosio.token", data);
+
+    if (data && data.length) {
+        return assetFromString(data[0]);
+    } else {
+        return { ...minimumDonationAmount, quantity: 0.0 };
+    }
+};

--- a/packages/webapp/src/_app/api/eosio.token-contract.ts
+++ b/packages/webapp/src/_app/api/eosio.token-contract.ts
@@ -11,7 +11,7 @@ export const getTokenBalanceForAccount = async (
         minimumDonationAmount.symbol
     );
 
-    if (data && data.length) {
+    if (data?.length) {
         return assetFromString(data[0]);
     } else {
         return { ...minimumDonationAmount, quantity: 0.0 };

--- a/packages/webapp/src/_app/api/eosio.token-contract.ts
+++ b/packages/webapp/src/_app/api/eosio.token-contract.ts
@@ -11,8 +11,6 @@ export const getTokenBalanceForAccount = async (
         minimumDonationAmount.symbol
     );
 
-    console.info("eosio.token", data);
-
     if (data && data.length) {
         return assetFromString(data[0]);
     } else {

--- a/packages/webapp/src/_app/api/index.ts
+++ b/packages/webapp/src/_app/api/index.ts
@@ -1,2 +1,3 @@
 export * from "./eden-contract";
+export * from "./eosio.token-contract";
 export * from "./interfaces";

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -11,7 +11,7 @@ import {
     MemberData,
     MemberStats,
 } from "members";
-import { getCommunityGlobals } from "_app/api";
+import { getCommunityGlobals, getTokenBalanceForAccount } from "_app/api";
 import {
     getCurrentInductions,
     getEndorsementsByInductionId,
@@ -209,6 +209,11 @@ export const queryDistributionsForAccount = (account: string) => ({
     queryFn: () => getDistributionsForAccount(account),
 });
 
+export const queryTokenBalanceForAccount = (account: string) => ({
+    queryKey: ["query_token_balance_for_account", account],
+    queryFn: () => getTokenBalanceForAccount(account),
+});
+
 export const queryInduction = (inductionId: string) => ({
     queryKey: ["query_induction", inductionId],
     queryFn: () => getInduction(inductionId),
@@ -256,6 +261,12 @@ export const useDistributionsForAccount = (account: string) =>
 export const useDistributionState = () =>
     useQuery({
         ...queryDistributionState(),
+    });
+
+export const useTokenBalanceForAccount = (account: string) =>
+    useQuery({
+        ...queryTokenBalanceForAccount(account),
+        enabled: Boolean(account),
     });
 
 export const useMemberListByAccountNames = (

--- a/packages/webapp/src/members/components/index.ts
+++ b/packages/webapp/src/members/components/index.ts
@@ -4,3 +4,4 @@ export * from "./member-collections";
 export * from "./member-holo-card";
 export * from "./member-social-links";
 export * from "./members-grid";
+export * from "./token-balance";

--- a/packages/webapp/src/members/components/member-card.tsx
+++ b/packages/webapp/src/members/components/member-card.tsx
@@ -6,17 +6,20 @@ import { SocialButton, ipfsUrl } from "_app";
 import { MemberData } from "../interfaces";
 import { MemberBio } from "./member-bio";
 import { MemberSocialLinks } from "./member-social-links";
+import { TokenBalance } from "./token-balance";
 
 interface Props {
     member: MemberData;
+    showBalance?: boolean;
 }
 
-export const MemberCard = ({ member }: Props) => {
+export const MemberCard = ({ member, showBalance }: Props) => {
     return (
         <div
             data-testid={`member-card-${member.account}`}
             className="px-2 flex flex-col max-w-2xl w-full"
         >
+            {showBalance && <TokenBalance member={member} />}
             <section className="py-5">
                 <MemberBio bio={member.bio} />
             </section>

--- a/packages/webapp/src/members/components/token-balance.tsx
+++ b/packages/webapp/src/members/components/token-balance.tsx
@@ -1,0 +1,29 @@
+import { assetToString, Link, Text, useTokenBalanceForAccount } from "_app";
+import { blockExplorerAccountBaseUrl } from "config";
+
+import { MemberData } from "../interfaces";
+
+interface Props {
+    member: MemberData;
+}
+
+export const TokenBalance = ({ member }: Props) => {
+    const { data: balance } = useTokenBalanceForAccount(member.account);
+
+    return (
+        <div>
+            <Text>
+                <strong>Balance:</strong>{" "}
+                {balance ? assetToString(balance) : "loading..."}{" "}
+                <span className="ml-4">
+                    <Link
+                        href={`${blockExplorerAccountBaseUrl}/${member.account}`}
+                        target="_blank"
+                    >
+                        History
+                    </Link>
+                </span>
+            </Text>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/members/[id].tsx
+++ b/packages/webapp/src/pages/members/[id].tsx
@@ -52,7 +52,7 @@ export const MemberPage = ({ account }: Props) => {
                         <div className="max-w-2xl">
                             <MemberHoloCard member={member} />
                         </div>
-                        <MemberCard member={member} />
+                        <MemberCard member={member} showBalance />
                     </div>
                 </Container>
                 <MemberCollections member={member} />


### PR DESCRIPTION
Adds a token balance component with a history link in the member profile page.
![image](https://user-images.githubusercontent.com/79721020/130793878-c4ce41a6-10e3-459e-bf25-cda288dd807a.png)
