### PR TITLE
Add election participation count query

### DIFF
--- a/packages/common/src/subchain/ReactSubchain.tsx
+++ b/packages/common/src/subchain/ReactSubchain.tsx
@@ -45,7 +45,14 @@ export function useCreateEdenChain(
 
 export const EdenChainContext = createContext<SubchainClient | null>(null);
 
-export function useQuery<T = any>(query: string): T {
+export interface Query<T> {
+    isLoading: boolean; // flags if the query is loading
+    data?: T; // has the query data when it's loaded or empty if not found
+    error?: any; // flags an error in case it fails to load the query
+}
+
+export function useQuery<T = any>(query: string): Query<T> {
+    console.info("using query...");
     const client = useContext(EdenChainContext);
     const [cachedQuery, setCachedQuery] = useState<string | null>();
     // non-signalling state
@@ -53,7 +60,7 @@ export function useQuery<T = any>(query: string): T {
         mounted: true,
         cachedClient: null as SubchainClient | null,
         subscribed: null as SubchainClient | null,
-        cachedQueryResult: null as any,
+        cachedQueryResult: { isLoading: false } as Query<T>,
     });
     useEffect(() => {
         return () => {
@@ -75,9 +82,16 @@ export function useQuery<T = any>(query: string): T {
         state.cachedClient = client;
         setCachedQuery(query);
         if (client?.subchain) {
+            state.cachedQueryResult = {
+                data: client.subchain.query(query).data,
+                isLoading: false,
+            };
             state.cachedQueryResult = client.subchain.query(query);
         } else {
-            state.cachedQueryResult = null;
+            state.cachedQueryResult = {
+                isLoading: false,
+                error: "subchain not present",
+            };
         }
     }
     return state.cachedQueryResult;
@@ -93,7 +107,7 @@ interface PageInfo {
 export function usePagedQuery<T = any>(
     query: string,
     pageSize: number,
-    getPageInfo: (result: T) => PageInfo | null | undefined
+    getPageInfo: (result: Query<T>) => PageInfo | null | undefined
 ) {
     const [args, setArgs] = useState(`first:${pageSize}`);
     const result = useQuery<T>(query.replace("@page@", args));

--- a/packages/common/src/subchain/ReactSubchain.tsx
+++ b/packages/common/src/subchain/ReactSubchain.tsx
@@ -48,7 +48,8 @@ export const EdenChainContext = createContext<SubchainClient | null>(null);
 export interface Query<T> {
     isLoading: boolean; // flags if the query is loading
     data?: T; // has the query data when it's loaded or empty if not found
-    errors?: any; // flags an error in case it fails to load the query
+    isError: boolean; // flags that an error happened
+    errors?: any; // contains the errors if there are any
 }
 
 export function useQuery<T = any>(query: string): Query<T> {
@@ -59,7 +60,7 @@ export function useQuery<T = any>(query: string): Query<T> {
         mounted: true,
         cachedClient: null as SubchainClient | null,
         subscribed: null as SubchainClient | null,
-        cachedQueryResult: { isLoading: false } as Query<T>,
+        cachedQueryResult: { isLoading: false, isError: false } as Query<T>,
     });
     useEffect(() => {
         return () => {
@@ -81,13 +82,16 @@ export function useQuery<T = any>(query: string): Query<T> {
         state.cachedClient = client;
         setCachedQuery(query);
         if (client?.subchain) {
+            const queryResult = client.subchain.query(query);
             state.cachedQueryResult = {
-                ...client.subchain.query(query),
+                ...queryResult,
                 isLoading: false,
+                isError: Boolean(queryResult.errors),
             };
         } else {
             state.cachedQueryResult = {
                 isLoading: true,
+                isError: false,
             };
         }
     }

--- a/packages/common/src/subchain/ReactSubchain.tsx
+++ b/packages/common/src/subchain/ReactSubchain.tsx
@@ -48,7 +48,7 @@ export const EdenChainContext = createContext<SubchainClient | null>(null);
 export interface Query<T> {
     isLoading: boolean; // flags if the query is loading
     data?: T; // has the query data when it's loaded or empty if not found
-    error?: any; // flags an error in case it fails to load the query
+    errors?: any; // flags an error in case it fails to load the query
 }
 
 export function useQuery<T = any>(query: string): Query<T> {
@@ -82,14 +82,13 @@ export function useQuery<T = any>(query: string): Query<T> {
         setCachedQuery(query);
         if (client?.subchain) {
             state.cachedQueryResult = {
-                data: client.subchain.query(query).data,
+                ...client.subchain.query(query),
                 isLoading: false,
             };
-            state.cachedQueryResult = client.subchain.query(query);
         } else {
             state.cachedQueryResult = {
                 isLoading: false,
-                error: "subchain not present",
+                errors: { message: "subchain not present" },
             };
         }
     }

--- a/packages/common/src/subchain/ReactSubchain.tsx
+++ b/packages/common/src/subchain/ReactSubchain.tsx
@@ -52,7 +52,6 @@ export interface Query<T> {
 }
 
 export function useQuery<T = any>(query: string): Query<T> {
-    console.info("using query...");
     const client = useContext(EdenChainContext);
     const [cachedQuery, setCachedQuery] = useState<string | null>();
     // non-signalling state

--- a/packages/common/src/subchain/ReactSubchain.tsx
+++ b/packages/common/src/subchain/ReactSubchain.tsx
@@ -87,8 +87,7 @@ export function useQuery<T = any>(query: string): Query<T> {
             };
         } else {
             state.cachedQueryResult = {
-                isLoading: false,
-                errors: { message: "subchain not present" },
+                isLoading: true,
             };
         }
     }

--- a/packages/example-history-app/src/components/header.tsx
+++ b/packages/example-history-app/src/components/header.tsx
@@ -19,11 +19,11 @@ export default function Header() {
                     <tbody>
                         <tr>
                             <td>block:</td>
-                            <td>{info?.data?.blockLog.head?.num}</td>
+                            <td>{info.data?.blockLog.head?.num}</td>
                         </tr>
                         <tr>
                             <td>eosio block:</td>
-                            <td>{info?.data?.blockLog.head?.eosioBlock.num}</td>
+                            <td>{info.data?.blockLog.head?.eosioBlock.num}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/packages/example-history-app/src/pages/index.tsx
+++ b/packages/example-history-app/src/pages/index.tsx
@@ -25,27 +25,25 @@ const query = `
 }`;
 
 interface QueryResult {
-    data?: {
-        members: {
-            pageInfo: {
-                hasPreviousPage: boolean;
-                hasNextPage: boolean;
-                startCursor: string;
-                endCursor: string;
-            };
-            edges: [
-                {
-                    node: {
-                        account: string;
-                        profile: {
-                            name: string;
-                            img: string;
-                            bio: string;
-                        };
-                    };
-                }
-            ];
+    members: {
+        pageInfo: {
+            hasPreviousPage: boolean;
+            hasNextPage: boolean;
+            startCursor: string;
+            endCursor: string;
         };
+        edges: [
+            {
+                node: {
+                    account: string;
+                    profile: {
+                        name: string;
+                        img: string;
+                        bio: string;
+                    };
+                };
+            }
+        ];
     };
 }
 
@@ -53,7 +51,7 @@ function Members() {
     const pagedResult = usePagedQuery<QueryResult>(
         query,
         4,
-        (result) => result?.data?.members.pageInfo
+        (result) => result.data?.members.pageInfo
     );
     return (
         <div style={{ flexGrow: 1, margin: "10px" }}>

--- a/packages/example-history-app/src/pages/simple_members.tsx
+++ b/packages/example-history-app/src/pages/simple_members.tsx
@@ -15,7 +15,7 @@ function Members() {
     const pagedResult = usePagedQuery(
         query,
         10,
-        (result) => result?.data?.members.pageInfo
+        (result) => result.data?.members.pageInfo
     );
     return (
         <Fragment>

--- a/packages/webapp/src/_app/hooks/box-queries.ts
+++ b/packages/webapp/src/_app/hooks/box-queries.ts
@@ -1,23 +1,15 @@
 import { useQuery } from "@edenos/common/dist/subchain";
 
-// todo: needs some review... ideally it should always return an object
-// with a nullable data, not an undefined query
-interface Query<T> {
-    data?: T;
-}
-type SubchainQuery<T> = Query<T> | undefined;
-
-const useSubchainQuery = <T>(query: string) =>
-    useQuery<SubchainQuery<T>>(query);
-
 export interface ElectionStatusQuery {
-    nextElection: string; // datetime iso string WITH timezone
-    electionThreshold: number;
-    numElectionParticipants: number;
+    status: {
+        nextElection: string; // iso datetime string WITH timezone
+        electionThreshold: number;
+        numElectionParticipants: number;
+    };
 }
 
 export const useElectionStatus = () =>
-    useSubchainQuery<ElectionStatusQuery>(`
+    useQuery<ElectionStatusQuery>(`
 {
     status {
         nextElection

--- a/packages/webapp/src/_app/hooks/box-queries.ts
+++ b/packages/webapp/src/_app/hooks/box-queries.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@edenos/common/dist/subchain";
+
+// todo: needs some review... ideally it should always return an object
+// with a nullable data, not an undefined query
+interface Query<T> {
+    data?: T;
+}
+type SubchainQuery<T> = Query<T> | undefined;
+
+const useSubchainQuery = <T>(query: string) =>
+    useQuery<SubchainQuery<T>>(query);
+
+export interface ElectionStatusQuery {
+    nextElection: string; // datetime iso string WITH timezone
+    electionThreshold: number;
+    numElectionParticipants: number;
+}
+
+export const useElectionStatus = () =>
+    useSubchainQuery<ElectionStatusQuery>(`
+{
+    status {
+        nextElection
+        electionThreshold
+        numElectionParticipants
+    }
+}
+`);

--- a/packages/webapp/src/_app/hooks/index.ts
+++ b/packages/webapp/src/_app/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./forms";
 export * from "./queries";
 export * from "./local-storage";
 export * from "./utils";
+export * from "./box-queries";

--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -13,6 +13,8 @@ import {
     useCountdown,
     useCurrentElection,
     useCurrentMember,
+    useEdenStatus,
+    useElectionStatus,
     useUALAccount,
 } from "_app";
 import {
@@ -191,6 +193,7 @@ export const ParticipationCard = ({ election }: Props) => {
                     </div>
                 )}
             </div>
+            <ParticipationCounter />
             <ConfirmParticipationModal
                 isOpen={showConfirmParticipationModal}
                 close={() => setShowConfirmParticipationModal(false)}
@@ -201,6 +204,22 @@ export const ParticipationCard = ({ election }: Props) => {
                 close={() => setShowCancelParticipationModal(false)}
             />
         </Container>
+    );
+};
+
+const ParticipationCounter = () => {
+    const status = useElectionStatus();
+    return (
+        status?.data?.status && (
+            <div>
+                <Text>
+                    Members Participating:{" "}
+                    <strong>
+                        {status.data.status.numElectionParticipants}
+                    </strong>
+                </Text>
+            </div>
+        )
     );
 };
 

--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -13,7 +13,6 @@ import {
     useCountdown,
     useCurrentElection,
     useCurrentMember,
-    useEdenStatus,
     useElectionStatus,
     useUALAccount,
 } from "_app";
@@ -208,19 +207,17 @@ export const ParticipationCard = ({ election }: Props) => {
 };
 
 const ParticipationCounter = () => {
-    const status = useElectionStatus();
-    return (
-        status?.data?.status && (
-            <div>
-                <Text>
-                    Members Participating:{" "}
-                    <strong>
-                        {status.data.status.numElectionParticipants}
-                    </strong>
-                </Text>
-            </div>
-        )
-    );
+    const { data: statusQueryResult } = useElectionStatus();
+    return statusQueryResult ? (
+        <div>
+            <Text>
+                Members Participating:{" "}
+                <strong>
+                    {statusQueryResult.status.numElectionParticipants}
+                </strong>
+            </Text>
+        </div>
+    ) : null;
 };
 
 interface CountdownProps {


### PR DESCRIPTION
- add the first box subchain query! 🎉
- shows the total number of participants on the current election
- if the query fails we simply don't show the component (it means that we don't depend on the box -- I think we should adopt this pattern whenever possible, so other eden communities are not forced to spin up a box with history... I also understand that this might be a deal breaker for some functionalities that depends on nice massaged data from history... hence why "whenever possible" -- thoughts?)
- it standardizes the `useQuery` from `ReactSubchain` with the same interface as the `react-query`, then we have a nice object to control when it's loading, has an error or has the query data result in fact.