### PR TITLE
useQuery: catch exceptions

### DIFF
--- a/packages/common/src/subchain/ReactSubchain.tsx
+++ b/packages/common/src/subchain/ReactSubchain.tsx
@@ -82,12 +82,20 @@ export function useQuery<T = any>(query: string): Query<T> {
         state.cachedClient = client;
         setCachedQuery(query);
         if (client?.subchain) {
-            const queryResult = client.subchain.query(query);
-            state.cachedQueryResult = {
-                ...queryResult,
-                isLoading: false,
-                isError: Boolean(queryResult.errors),
-            };
+            try {
+                const queryResult = client.subchain.query(query);
+                state.cachedQueryResult = {
+                    ...queryResult,
+                    isLoading: false,
+                    isError: Boolean(queryResult.errors),
+                };
+            } catch (e: any) {
+                state.cachedQueryResult = {
+                    isLoading: false,
+                    isError: true,
+                    errors: [{ message: e + "" }],
+                };
+            }
         } else {
             state.cachedQueryResult = {
                 isLoading: true,


### PR DESCRIPTION
A server glitch today caused an exception to slip through `useQuery`, stopping the site from rendering