### PR TITLE
More Zoom tweaks for marketplace submission

### DIFF
--- a/packages/webapp/src/_app/eos/ual/softkey/softkey-ual-authenticator.tsx
+++ b/packages/webapp/src/_app/eos/ual/softkey/softkey-ual-authenticator.tsx
@@ -62,7 +62,7 @@ export class SoftkeyAuthenticator extends Authenticator {
     // TODO: Style it up
     public getStyle(): ButtonStyle {
         return {
-            icon: "./images/eden-logo-penta.svg",
+            icon: "/images/eden-logo-penta.svg",
             text: AUTHENTICATOR_NAME,
             textColor: "black",
             background: "gray",

--- a/packages/webapp/src/pages/oauth/videoconf.tsx
+++ b/packages/webapp/src/pages/oauth/videoconf.tsx
@@ -8,12 +8,14 @@ import {
     useZoomAccountJWT,
     encryptSecretForPublishing,
     onError,
+    useCurrentMember,
 } from "_app";
 import {
     Button,
     CallToAction,
     Container,
     Heading,
+    Link,
     Loader,
     Text,
 } from "_app/ui";
@@ -25,6 +27,7 @@ import {
     zoomConnectAccountLink,
     generateZoomMeetingLink,
 } from "_api/zoom-commons";
+import { ROUTES } from "_app/config";
 
 export const getServerSideProps: GetServerSideProps = async ({
     query,
@@ -35,15 +38,12 @@ export const getServerSideProps: GetServerSideProps = async ({
     let newZoomAccountJWT = null;
 
     if (oauthCode) {
-        const oauthDataResponse = await zoomRequestAuth(oauthCode);
-        if (oauthDataResponse.error) {
-            console.error(
-                "fail to auth zoom code",
-                oauthCode,
-                oauthDataResponse
-            );
-        } else {
+        try {
+            const oauthDataResponse = await zoomRequestAuth(oauthCode);
+            if (oauthDataResponse.error) throw oauthDataResponse;
             newZoomAccountJWT = oauthDataResponse;
+        } catch (e) {
+            console.error("Failed to auth Zoom code", oauthCode, e);
         }
     }
 
@@ -62,9 +62,12 @@ interface Props {
 
 export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
+    const { data: currentMember } = useCurrentMember();
     const [_zoomAccountJWT, setZoomAccountJWT] = useZoomAccountJWT(undefined);
     const router = useRouter();
     const [redirectMessage, setRedirectMessage] = useState("");
+
+    console.log(currentMember);
 
     useEffect(() => {
         if (newZoomAccountJWT) {
@@ -90,8 +93,21 @@ export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
                     <Text className="pb-8">{redirectMessage}</Text>
                     <Loader />
                 </Container>
-            ) : ualAccount ? ( // TODO: maybe we can even remove the ualAccount guard from this to allow the Zoom Marketplace review
-                <ZoomTestContainer ualAccount={ualAccount} />
+            ) : currentMember ? (
+                <Container className="space-y-4">
+                    <Heading size={2}>Your Zoom account is linked</Heading>
+                    <Text>You're ready to participate in Eden elections!</Text>
+                </Container>
+            ) : ualAccount ? (
+                <Container className="space-y-4">
+                    <Heading size={2}>Your Zoom account is linked</Heading>
+                    <Text>
+                        <Link href={ROUTES.INDUCTION.href}>
+                            Become a member of Eden
+                        </Link>{" "}
+                        to participate in Eden elections.
+                    </Text>
+                </Container>
             ) : (
                 <CallToAction buttonLabel="Sign in" onClick={ualShowModal}>
                     Welcome to Eden. Sign in using your wallet.
@@ -103,6 +119,7 @@ export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
 
 export default ZoomOauthPage;
 
+// Use this component to easily test the Zoom integration
 const ZoomTestContainer = ({ ualAccount }: any) => {
     const [zoomAccountJWT, setZoomAccountJWT] = useZoomAccountJWT(undefined);
 

--- a/packages/webapp/src/pages/oauth/videoconf.tsx
+++ b/packages/webapp/src/pages/oauth/videoconf.tsx
@@ -67,8 +67,6 @@ export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
     const router = useRouter();
     const [redirectMessage, setRedirectMessage] = useState("");
 
-    console.log(currentMember);
-
     useEffect(() => {
         if (newZoomAccountJWT) {
             setZoomAccountJWT(newZoomAccountJWT);

--- a/packages/webapp/src/pages/oauth/videoconf.tsx
+++ b/packages/webapp/src/pages/oauth/videoconf.tsx
@@ -81,7 +81,7 @@ export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
     }, []);
 
     return (
-        <SideNavLayout title="Zoom Test" className="divide-y border-b">
+        <SideNavLayout title="Video Conferencing" className="divide-y border-b">
             <Container>
                 <Heading size={1}>Video conferencing for EdenOS</Heading>
             </Container>


### PR DESCRIPTION
* The UAL Softkey authenticator button logo was a relative path, so the logo wouldn't show up when trying to log in from non-root pages. Fixed.
* The Zoom oauth landing page is also the page people are sent to when they click on our EdenOS Zoom app listing from the marketplace. In some cases, visiting from the app listing resulted in a 500 as this page wasn't handling certain errors. In other cases, redirected users were shown the "create a dummy zoom meeting link" UI. Now, they're presented with a confirmation that they've connected Zoom and/or a call to action to sign in or join Eden to participate.