### PR TITLE
Make zoom redirect URL dynamic

### DIFF
--- a/packages/webapp/.env
+++ b/packages/webapp/.env
@@ -1,3 +1,4 @@
+NEXT_PUBLIC_BASE_URL = "http://localhost:3000"
 NEXT_PUBLIC_EOS_CHAIN_ID = "f16b1833c747c43682f4386fca9cbb327929334a762755ebec17f6f23c9b8a12"
 NEXT_PUBLIC_EOS_RPC_PROTOCOL = "https"
 # NEXT_PUBLIC_EOS_RPC_HOST = "waxtestnet.greymass.com" # greymass wax is not 2.0 :(

--- a/packages/webapp/src/config.ts
+++ b/packages/webapp/src/config.ts
@@ -1,7 +1,11 @@
 import { ValidUploadActions } from "@edenos/common";
 import { assetFromString } from "./_app/utils/asset";
 
+const baseUrl =
+    process.env.NEXT_PUBLIC_VERCEL_URL ?? process.env.NEXT_PUBLIC_BASE_URL;
+
 if (
+    !baseUrl ||
     !process.env.NEXT_PUBLIC_EOS_RPC_PROTOCOL ||
     !process.env.NEXT_PUBLIC_EOS_RPC_HOST ||
     !process.env.NEXT_PUBLIC_EOS_RPC_PORT ||
@@ -34,6 +38,8 @@ if (
 }
 
 console.info(`>>> Loaded Configs:
+VERCEL_URL="${process.env.NEXT_PUBLIC_VERCEL_URL}"
+BASE_URL="${process.env.NEXT_PUBLIC_BASE_URL}"
 EOS_RPC_PROTOCOL="${process.env.NEXT_PUBLIC_EOS_RPC_PROTOCOL}"
 EOS_RPC_HOST="${process.env.NEXT_PUBLIC_EOS_RPC_HOST}"
 EOS_RPC_PORT="${process.env.NEXT_PUBLIC_EOS_RPC_PORT}"
@@ -167,5 +173,5 @@ export const devUseFixtureData =
 export const zoom = {
     clientKey: process.env.NEXT_PUBLIC_ZOOM_CLIENT_ID || "",
     clientSecret: process.env.ZOOM_CLIENT_SECRET || "",
-    oauthRedirect: `http://localhost:3000/oauth/videoconf`, // TODO: make the domain dynamic
+    oauthRedirect: `${baseUrl}/oauth/videoconf`,
 };


### PR DESCRIPTION
Vercel has a predefined env var for this purpose, but sometimes we're running locally and others may want to deploy this somewhere other than Vercel. So in the absence of a Vercel-provided `NEXT_PUBLIC_VERCEL_URL`, we can define and use `NEXT_PUBLIC_BASE_URL`.