### PR TITLE
Do not depend on VERCEL_URL

### DIFF
--- a/packages/webapp/src/config.ts
+++ b/packages/webapp/src/config.ts
@@ -1,11 +1,8 @@
 import { ValidUploadActions } from "@edenos/common";
 import { assetFromString } from "./_app/utils/asset";
 
-const baseUrl =
-    process.env.NEXT_PUBLIC_VERCEL_URL ?? process.env.NEXT_PUBLIC_BASE_URL;
-
 if (
-    !baseUrl ||
+    !process.env.NEXT_PUBLIC_BASE_URL ||
     !process.env.NEXT_PUBLIC_EOS_RPC_PROTOCOL ||
     !process.env.NEXT_PUBLIC_EOS_RPC_HOST ||
     !process.env.NEXT_PUBLIC_EOS_RPC_PORT ||
@@ -38,7 +35,6 @@ if (
 }
 
 console.info(`>>> Loaded Configs:
-VERCEL_URL="${process.env.NEXT_PUBLIC_VERCEL_URL}"
 BASE_URL="${process.env.NEXT_PUBLIC_BASE_URL}"
 EOS_RPC_PROTOCOL="${process.env.NEXT_PUBLIC_EOS_RPC_PROTOCOL}"
 EOS_RPC_HOST="${process.env.NEXT_PUBLIC_EOS_RPC_HOST}"
@@ -173,5 +169,5 @@ export const devUseFixtureData =
 export const zoom = {
     clientKey: process.env.NEXT_PUBLIC_ZOOM_CLIENT_ID || "",
     clientSecret: process.env.ZOOM_CLIENT_SECRET || "",
-    oauthRedirect: `${baseUrl}/oauth/videoconf`,
+    oauthRedirect: `${process.env.NEXT_PUBLIC_BASE_URL}/oauth/videoconf`,
 };


### PR DESCRIPTION
Follow-up from #494.

In #494, I needed to merge to `main` to see what the `NEXT_PUBLIC_VERCEL_URL` would be defined as in the deployed dev environment. Unfortunately, it's defined as the randomized path to the PREVIEW deployment, and not as the friendly `eden-dev.vercel.app` or `genesis.eden.eoscommunity.org` path. Not a big surprise, but had to test it.

![image](https://user-images.githubusercontent.com/7911424/133495508-07ae4c3b-64c0-4469-b61b-440887a1be07.png)

So instead of depending on `NEXT_PUBLIC_VERCEL_URL`, we'll just define this explicitly using `NEXT_PUBLIC_BASE_URL`.