### PR TITLE
EdenOS Release 0.2.9

### DIFF
--- a/packages/webapp/src/inductions/components/induction-lists/endorser-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/endorser-inductions.tsx
@@ -37,16 +37,18 @@ export const EndorserInductions = ({
     );
 };
 
+// TODO: Show witness names again once we have the blockchain microchain state machine in place for these tables.
+// They're kicking off too many requests and causing the RPC nodes to rate limit individual user IPs.
 const ENDORSER_INDUCTION_COLUMNS: InductionTable.Column[] = [
     {
         key: "invitee",
         label: "Invitee",
     },
-    {
-        key: "inviterAndWitnesses",
-        label: "Inviter & witnesses",
-        className: "hidden md:flex",
-    },
+    // {
+    //     key: "inviterAndWitnesses",
+    //     label: "Inviter & witnesses",
+    //     className: "hidden md:flex",
+    // },
     {
         key: "time_remaining",
         label: "Time remaining",
@@ -76,14 +78,14 @@ const getTableData = (
         return {
             key: `${endorsement.induction_id}-${endorsement.id}`,
             invitee,
-            inviterAndWitnesses: induction ? (
-                <EndorsersNames
-                    induction={induction}
-                    skipEndorser={endorsement.endorser}
-                />
-            ) : (
-                "Unknown"
-            ),
+            // inviterAndWitnesses: induction ? (
+            //     <EndorsersNames
+            //         induction={induction}
+            //         skipEndorser={endorsement.endorser}
+            //     />
+            // ) : (
+            //     "Unknown"
+            // ),
             time_remaining: getInductionRemainingTimeDays(induction),
             status: induction ? (
                 <InductionStatusButton

--- a/packages/webapp/src/inductions/components/induction-lists/inviter-inductions.tsx
+++ b/packages/webapp/src/inductions/components/induction-lists/inviter-inductions.tsx
@@ -17,16 +17,18 @@ export const InviterInductions = ({ inductions }: Props) => (
     />
 );
 
+// TODO: Show witness names again once we have the blockchain microchain state machine in place for these tables.
+// They're kicking off too many requests and causing the RPC nodes to rate limit individual user IPs.
 const INVITER_INDUCTION_COLUMNS: InductionTable.Column[] = [
     {
         key: "invitee",
         label: "Invitee",
     },
-    {
-        key: "inviter_witnesses",
-        label: "Witnesses",
-        className: "hidden md:flex",
-    },
+    // {
+    //     key: "inviter_witnesses",
+    //     label: "Witnesses",
+    //     className: "hidden md:flex",
+    // },
     {
         key: "time_remaining",
         label: "Time remaining",
@@ -43,12 +45,12 @@ const getTableData = (inductions: Induction[]): InductionTable.Row[] => {
     return inductions.map((induction) => ({
         key: induction.id,
         invitee: induction.new_member_profile.name || induction.invitee,
-        inviter_witnesses: (
-            <EndorsersNames
-                induction={induction}
-                skipEndorser={induction.inviter}
-            />
-        ),
+        // inviter_witnesses: (
+        //     <EndorsersNames
+        //         induction={induction}
+        //         skipEndorser={induction.inviter}
+        //     />
+        // ),
         time_remaining: getInductionRemainingTimeDays(induction),
         status: (
             <InductionStatusButton


### PR DESCRIPTION
Fix: Remove witnesses queries from inviter and witness invite tables to reduce number of RPC calls. This was causing users participating in more than a few inductions to get blocked by RPC nodes for 10 minute at a time due to too many calls all at once from their IP.