### PR TITLE
Zoom only eat cookies

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -24,6 +24,7 @@
         "ipfs-http-client": "^50.0.0",
         "ipfs-only-hash": "^4.0.0",
         "next": "~10",
+        "nookies": "^2.5.2",
         "nprogress": "^0.2.0",
         "react": "~17",
         "react-cool-dimensions": "^2.0.3",

--- a/packages/webapp/src/_api/schemas/meetings.ts
+++ b/packages/webapp/src/_api/schemas/meetings.ts
@@ -6,7 +6,6 @@ export enum AvailableMeetingClients {
 
 export const meetingLinkRequestSchema = z.object({
     client: z.nativeEnum(AvailableMeetingClients),
-    accessToken: z.string(),
     topic: z.string(),
     duration: z.number(),
     startTime: z.string(),

--- a/packages/webapp/src/_api/zoom-commons.ts
+++ b/packages/webapp/src/_api/zoom-commons.ts
@@ -106,7 +106,7 @@ export const setZoomJWTCookie = (zoomAccountJWT: any, res: any) => {
             {
                 httpOnly: true,
                 path: "/api",
-                secure: false, // TODO: change to true
+                secure: true,
             }
         );
     } else {
@@ -114,7 +114,7 @@ export const setZoomJWTCookie = (zoomAccountJWT: any, res: any) => {
         destroyCookie({ res }, "zoomAccountJWT", {
             httpOnly: true,
             path: "/api",
-            secure: false,
+            secure: true,
         });
     }
 };

--- a/packages/webapp/src/_api/zoom-commons.ts
+++ b/packages/webapp/src/_api/zoom-commons.ts
@@ -1,3 +1,5 @@
+import { setCookie, destroyCookie } from "nookies";
+
 import { zoom } from "config";
 
 import { AvailableMeetingClients } from "./schemas";
@@ -57,7 +59,9 @@ export const zoomAccountJWTIsExpired = (zoomAccountJWT: ZoomAccountJWT) => {
     if (accessTokenEncodedData.length !== 3)
         throw new Error("invalid zoom jwt payload");
 
-    const accessTokenData = JSON.parse(atob(accessTokenEncodedData[1]));
+    const accessTokenData = JSON.parse(
+        Buffer.from(accessTokenEncodedData[1], "base64").toString()
+    );
     if (!accessTokenData.exp) {
         throw new Error("can't parse zoom jwt expiration date");
     }
@@ -69,38 +73,15 @@ export const zoomResponseIsInvalidAccess = (response: any) => {
 };
 
 export const generateZoomMeetingLink = async (
-    zoomAccountJWT: any,
-    setZoomAccountJWT: (updatedJwt: any) => void,
+    setZoomLinkedAccount: (isZoomAccountLinked: boolean) => void,
     topic: string,
     durationInMinutes: number,
     startTime: string
 ) => {
-    let accessToken = zoomAccountJWT.access_token;
-    if (!accessToken) {
-        throw new Error("Invalid AccessToken");
-    }
-
-    if (zoomAccountJWTIsExpired(zoomAccountJWT)) {
-        const newTokensResponse = await fetch(`/api/refresh-zoom`, {
-            method: "POST",
-            body: JSON.stringify({
-                refreshToken: zoomAccountJWT.refresh_token,
-            }),
-        });
-
-        const newTokens = await newTokensResponse.json();
-        if (!newTokensResponse.ok) {
-            setZoomAccountJWT(undefined);
-        }
-
-        setZoomAccountJWT(newTokens);
-        accessToken = newTokens.access_token;
-    }
-
     const response = await fetch(`/api/meeting-links`, {
         method: "POST",
+        credentials: "include",
         body: JSON.stringify({
-            accessToken,
             client: AvailableMeetingClients.Zoom,
             topic,
             duration: durationInMinutes,
@@ -110,8 +91,30 @@ export const generateZoomMeetingLink = async (
 
     const responseData = await response.json();
     if (zoomResponseIsInvalidAccess(responseData)) {
-        setZoomAccountJWT(undefined);
+        setZoomLinkedAccount(false);
     }
 
     return responseData;
+};
+
+export const setZoomJWTCookie = (zoomAccountJWT: any, res: any) => {
+    if (zoomAccountJWT) {
+        setCookie(
+            { res },
+            "zoomAccountJWT",
+            Buffer.from(JSON.stringify(zoomAccountJWT)).toString("base64"),
+            {
+                httpOnly: true,
+                path: "/api",
+                secure: false, // TODO: change to true
+            }
+        );
+    } else {
+        console.info("destroying cookie");
+        destroyCookie({ res }, "zoomAccountJWT", {
+            httpOnly: true,
+            path: "/api",
+            secure: false,
+        });
+    }
 };

--- a/packages/webapp/src/_app/hooks/local-storage.ts
+++ b/packages/webapp/src/_app/hooks/local-storage.ts
@@ -33,5 +33,5 @@ export const useLocalStorage = (key: string, initialValue: any) => {
     return [storedValue, setValue];
 };
 
-export const useZoomAccountJWT = (zoomAccountJWT?: ZoomAccountJWT) =>
-    useLocalStorage("zoomAccountJWT", zoomAccountJWT);
+export const useZoomLinkedAccount = (zoomLinkedAccount: boolean) =>
+    useLocalStorage("zoomLinkedAccount", zoomLinkedAccount);

--- a/packages/webapp/src/elections/components/ongoing-election-components/meeting-link/meeting-link.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/meeting-link/meeting-link.tsx
@@ -4,12 +4,11 @@ import { Dayjs } from "dayjs";
 import {
     delay,
     encryptSecretForPublishing,
-    onError,
     useEncryptedData,
     useMemberGroupParticipants,
     useUALAccount,
     useVoteDataRow,
-    useZoomAccountJWT,
+    useZoomLinkedAccount,
 } from "_app";
 import { generateZoomMeetingLink } from "_api/zoom-commons";
 import { setElectionMeeting } from "elections/transactions";
@@ -48,7 +47,9 @@ export const MeetingLink = ({
     stage,
 }: RequestMeetingLinkProps) => {
     const [ualAccount] = useUALAccount();
-    const [zoomAccountJWT, setZoomAccountJWT] = useZoomAccountJWT(undefined);
+    const [zoomLinkedAccount, setZoomLinkedAccount] = useZoomLinkedAccount(
+        false
+    );
     const [showMeetingModal, setShowMeetingModal] = useState(false);
 
     const { show: showPasswordModal } = usePasswordModal();
@@ -78,7 +79,7 @@ export const MeetingLink = ({
     let meetingStep = MeetingStep.LinkZoomAccount;
     if (encryptedData) {
         meetingStep = MeetingStep.RetrieveMeetingLink;
-    } else if (zoomAccountJWT || freeformMeetingLinksEnabled) {
+    } else if (zoomLinkedAccount || freeformMeetingLinksEnabled) {
         meetingStep = MeetingStep.CreateMeetingLink;
     }
 
@@ -137,8 +138,7 @@ export const MeetingLink = ({
         const durationInMinutes = meetingDurationMs / 1000 / 60;
 
         const responseData = await generateZoomMeetingLink(
-            zoomAccountJWT,
-            setZoomAccountJWT,
+            setZoomLinkedAccount,
             topic,
             durationInMinutes,
             meetingStartTime.toISOString()

--- a/packages/webapp/src/pages/api/meeting-links.ts
+++ b/packages/webapp/src/pages/api/meeting-links.ts
@@ -1,12 +1,22 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { BadRequestError, handleErrors } from "@edenos/common";
+import {
+    UnauthorizedRequestError,
+    BadRequestError,
+    handleErrors,
+} from "@edenos/common";
 import { v4 as uuidv4 } from "uuid";
+import { parseCookies } from "nookies";
 
 import {
     MeetingLinkRequest,
     meetingLinkRequestSchema,
     AvailableMeetingClients,
 } from "_api/schemas";
+import {
+    zoomRefreshAuth,
+    zoomAccountJWTIsExpired,
+    setZoomJWTCookie,
+} from "_api/zoom-commons";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
     switch (req.method) {
@@ -21,13 +31,15 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 };
 
 const handleNewMeeting = async (req: NextApiRequest, res: NextApiResponse) => {
+    const parsedCookies = parseCookies({ req });
+
     const result = meetingLinkRequestSchema.safeParse(JSON.parse(req.body));
     if (!result.success) {
         return handleErrors(res, new BadRequestError(result.error.flatten()));
     }
 
     try {
-        const meeting = await generateMeeting(result.data);
+        const meeting = await generateMeeting(parsedCookies, result.data, res);
         return res.status(200).json({ meeting });
     } catch (error) {
         console.error(error);
@@ -35,11 +47,14 @@ const handleNewMeeting = async (req: NextApiRequest, res: NextApiResponse) => {
     }
 };
 
-export const generateMeeting = async (meetingRequest: MeetingLinkRequest) => {
-    console.info(meetingRequest);
+export const generateMeeting = async (
+    cookies: any,
+    meetingRequest: MeetingLinkRequest,
+    res: NextApiResponse
+) => {
     switch (meetingRequest.client as AvailableMeetingClients) {
         case AvailableMeetingClients.Zoom:
-            return generateZoomMeeting(meetingRequest);
+            return generateZoomMeeting(cookies, meetingRequest, res);
         default:
             throw new BadRequestError("meeting client not supported");
     }
@@ -49,7 +64,23 @@ export const generateMeeting = async (meetingRequest: MeetingLinkRequest) => {
  * Zoom Meeting Create API can be found here:
  * https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingcreate
  */
-const generateZoomMeeting = async (meetingRequest: MeetingLinkRequest) => {
+const generateZoomMeeting = async (
+    cookies: any,
+    meetingRequest: MeetingLinkRequest,
+    res: NextApiResponse
+) => {
+    if (!cookies.zoomAccountJWT) {
+        throw new UnauthorizedRequestError(["missing zoom account JWT"]);
+    }
+
+    let zoomAccountJWT = JSON.parse(
+        Buffer.from(cookies.zoomAccountJWT, "base64").toString()
+    );
+    if (zoomAccountJWTIsExpired(zoomAccountJWT)) {
+        zoomAccountJWT = await zoomRefreshAuth(zoomAccountJWT.refresh_token);
+        setZoomJWTCookie(zoomAccountJWT, res);
+    }
+
     const body = {
         topic: meetingRequest.topic,
         duration: meetingRequest.duration,
@@ -66,7 +97,7 @@ const generateZoomMeeting = async (meetingRequest: MeetingLinkRequest) => {
     const response = await fetch(`https://api.zoom.us/v2/users/me/meetings`, {
         method: "POST",
         headers: {
-            Authorization: `Bearer ${meetingRequest.accessToken}`,
+            Authorization: `Bearer ${zoomAccountJWT.access_token}`,
             "Content-Type": "application/json",
         },
         body: JSON.stringify(body),

--- a/packages/webapp/src/pages/oauth/videoconf.tsx
+++ b/packages/webapp/src/pages/oauth/videoconf.tsx
@@ -5,10 +5,10 @@ import { useRouter } from "next/router";
 import {
     SideNavLayout,
     useUALAccount,
-    useZoomAccountJWT,
     encryptSecretForPublishing,
     onError,
     useCurrentMember,
+    useZoomLinkedAccount,
 } from "_app";
 import {
     Button,
@@ -27,50 +27,54 @@ import {
     zoomRequestAuth,
     zoomConnectAccountLink,
     generateZoomMeetingLink,
+    setZoomJWTCookie,
 } from "_api/zoom-commons";
 
 export const getServerSideProps: GetServerSideProps = async ({
     query,
-    req,
+    res,
 }) => {
     const oauthCode = (query.code as string) || "";
     const oauthState = (query.state as string) || "";
-    let newZoomAccountJWT = null;
+    let isZoomLinked = false;
 
     if (oauthCode) {
         try {
             const oauthDataResponse = await zoomRequestAuth(oauthCode);
             if (oauthDataResponse.error) throw oauthDataResponse;
-            newZoomAccountJWT = oauthDataResponse;
+            setZoomJWTCookie(oauthDataResponse, res);
+            isZoomLinked = true;
         } catch (e) {
+            setZoomJWTCookie(undefined, res);
             console.error("Failed to auth Zoom code", oauthCode, e);
         }
     }
 
     return {
         props: {
-            newZoomAccountJWT,
+            isZoomLinked,
             oauthState,
         },
     };
 };
 
 interface Props {
-    newZoomAccountJWT: any;
+    isZoomLinked: boolean;
     oauthState: string;
 }
 
-export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
+export const ZoomOauthPage = ({ isZoomLinked, oauthState }: Props) => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
     const { data: currentMember } = useCurrentMember();
-    const [_zoomAccountJWT, setZoomAccountJWT] = useZoomAccountJWT(undefined);
+    const [_zoomLinkedAccount, setZoomLinkedAccount] = useZoomLinkedAccount(
+        false
+    );
     const router = useRouter();
     const [redirectMessage, setRedirectMessage] = useState("");
 
     useEffect(() => {
-        if (newZoomAccountJWT) {
-            setZoomAccountJWT(newZoomAccountJWT);
-
+        if (isZoomLinked) {
+            setZoomLinkedAccount(isZoomLinked);
             if (oauthState === "request-election-link") {
                 setRedirectMessage(
                     "Hold tight while we redirect you back to your in-progress election round."
@@ -85,6 +89,7 @@ export const ZoomOauthPage = ({ newZoomAccountJWT, oauthState }: Props) => {
             <Container>
                 <Heading size={1}>Video conferencing for EdenOS</Heading>
             </Container>
+            {/* Easy Zoom Tester Container: <ZoomTestContainer ualAccount={ualAccount} /> */}
             {redirectMessage ? (
                 <Container className="space-y-4 py-16 text-center">
                     <Heading size={2}>Your Zoom account is linked</Heading>
@@ -119,13 +124,14 @@ export default ZoomOauthPage;
 
 // Use this component to easily test the Zoom integration
 const ZoomTestContainer = ({ ualAccount }: any) => {
-    const [zoomAccountJWT, setZoomAccountJWT] = useZoomAccountJWT(undefined);
+    const [zoomLinkedAccount, setZoomLinkedAccount] = useZoomLinkedAccount(
+        false
+    );
 
     const doGenerateZoomMeetingLink = async () => {
         try {
             const responseData = await generateZoomMeetingLink(
-                zoomAccountJWT,
-                setZoomAccountJWT,
+                setZoomLinkedAccount,
                 `Test Eden Election #${Math.floor(
                     Math.random() * 100_000_000
                 )}`,
@@ -172,7 +178,7 @@ const ZoomTestContainer = ({ ualAccount }: any) => {
 
     return (
         <Container className="space-y-4">
-            {zoomAccountJWT ? (
+            {zoomLinkedAccount ? (
                 <>
                     <Text>
                         Thanks for connecting Eden to your Zoom account.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3847,6 +3847,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 copy-to-clipboard@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
@@ -7955,6 +7960,14 @@ node-releases@^1.1.69, node-releases@^1.1.70, node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
+nookies@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/nookies/-/nookies-2.5.2.tgz#cc55547efa982d013a21475bd0db0c02c1b35b27"
+  integrity sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==
+  dependencies:
+    cookie "^0.4.1"
+    set-cookie-parser "^2.4.6"
+
 nopt@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
@@ -9694,6 +9707,11 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 setimmediate@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
🍪

This PR addresses the Zoom Security Review concerns.

For that we moved our Zoom Account JWT to a cookie as opposed of using localstorage -- the rationale is that JS code cannot have access to Zoom JWT tokens; hence, a cookie with `httpOnly` is being used.