### PR TITLE
Fix last election datetime formatter on election page.

### DIFF
--- a/packages/webapp/src/elections/components/registration-election-components/video-upload-cta.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/video-upload-cta.tsx
@@ -11,7 +11,7 @@ export const ElectionVideoUploadCTA = () => {
     if (isLoading) return <LoadingContainer />;
     if (!electionState?.last_election_time) return null;
 
-    const deadline = dayjs(electionState?.last_election_time + "z").add(
+    const deadline = dayjs(electionState?.last_election_time + "Z").add(
         2,
         "days"
     );


### PR DESCRIPTION
This was causing the post-election `/election` page to crash on certain browsers after our test today.