### PR TITLE
Don't hide election schedule during pre-election seeding

### DIFF
--- a/packages/webapp/src/elections/components/registration-election.tsx
+++ b/packages/webapp/src/elections/components/registration-election.tsx
@@ -16,7 +16,7 @@ export const RegistrationElection = ({ election }: Props) => {
     return (
         <>
             <ParticipationCard election={election} />
-            {election?.electionState === ElectionStatus.Registration && (
+            {election?.electionState !== ElectionStatus.InitVoters && (
                 <>
                     <ElectionScheduleSegment />
                     <ElectionVideoUploadCTA />


### PR DESCRIPTION
This is a follow-up to #559.

#559 fixed the problem, but it also unintentionally hides the election schedule when the election flips to the `Seeding` state within the 24 hours preceding the start of the election. We want to keep that election schedule around!

This PR tightens the logic of the fix in #559 to only hide the offending sections during the `InitVoters` state between `Seeding` and `Active` (which should only last a few seconds.)

The fix in #559 was retested and still effective.