### PR TITLE
EdenOS Release 0.2.18

### DIFF
--- a/packages/webapp/src/elections/components/registration-election.tsx
+++ b/packages/webapp/src/elections/components/registration-election.tsx
@@ -16,7 +16,7 @@ export const RegistrationElection = ({ election }: Props) => {
     return (
         <>
             <ParticipationCard election={election} />
-            {election?.electionState === ElectionStatus.Registration && (
+            {election?.electionState !== ElectionStatus.InitVoters && (
                 <>
                     <ElectionScheduleSegment />
                     <ElectionVideoUploadCTA />


### PR DESCRIPTION
- Follow up to release 0.2.17 And #559 
- Fix: Election schedule and more information should still show up during the 24-hour seeding window prior to the start of an election.