### PR TITLE
EdenOS Release 0.2.21 (one more change!)

### DIFF
--- a/packages/webapp/src/pages/election/round-video-upload.tsx
+++ b/packages/webapp/src/pages/election/round-video-upload.tsx
@@ -50,7 +50,7 @@ export const RoundVideoUploadPage = () => {
     if (isError || !currentElection) return <ErrorLoadingElection />;
 
     const uploadLimitTime = electionState
-        ? dayjs(electionState.last_election_time + "Z").add(48, "hour")
+        ? dayjs(electionState.last_election_time + "Z").add(2, "weeks")
         : dayjs().add(1, "day");
 
     const isUploadExpired =


### PR DESCRIPTION
- Adds the 2-week video-upload expiration to one more place the frontend code needs it. (#575)