### PR TITLE
Fix bug related to withdrawal enhancements

### DIFF
--- a/packages/webapp/src/members/transactions.ts
+++ b/packages/webapp/src/members/transactions.ts
@@ -1,4 +1,4 @@
-import { Asset, assetToString } from "_app";
+import { Asset, assetFromString, assetToString } from "_app";
 import { edenContractAccount, tokenConfig } from "config";
 
 import { DistributionAccount } from "delegates/interfaces";
@@ -25,23 +25,25 @@ export const withdrawAndTransfer = (
     ];
 
     const sweepAvailableDistributions =
-        distributions?.map((distribution) => {
-            const { distributionTime, rank, balance } = distribution;
-            return {
-                account: edenContractAccount,
-                name: "fundtransfer",
-                authorization,
-                data: {
-                    from: authorizerAccount,
-                    distribution_time: distributionTime.replace(/Z$/, ""),
-                    rank,
-                    to: authorizerAccount,
-                    amount: balance,
-                    memo:
-                        "Claiming available delegate funds from EdenOS profile page",
-                },
-            };
-        }) ?? [];
+        distributions
+            ?.filter((d) => assetFromString(d.balance).quantity > 0)
+            .map((distribution) => {
+                const { distributionTime, rank, balance } = distribution;
+                return {
+                    account: edenContractAccount,
+                    name: "fundtransfer",
+                    authorization,
+                    data: {
+                        from: authorizerAccount,
+                        distribution_time: distributionTime.replace(/Z$/, ""),
+                        rank,
+                        to: authorizerAccount,
+                        amount: balance,
+                        memo:
+                            "Claiming available delegate funds from EdenOS profile page",
+                    },
+                };
+            }) ?? [];
 
     const withdrawFunds = {
         account: edenContractAccount,


### PR DESCRIPTION
1. Delegate successfully withdraws funds. (The first time they do this, all of their available distributions are moved from the distribution accounts to their personal Eden account.)
2. Delegate tries to withdraw again, but it fails. This is because we're trying to claim distributions with 0 balances...again.)

This filters those 0-amount `fundtransfer` actions out.