### PR TITLE
Add induction check on donate and fix microchain

### DIFF
--- a/contracts/eden/include/events.hpp
+++ b/contracts/eden/include/events.hpp
@@ -30,6 +30,12 @@ namespace eden
    //
    //    election_event_end
 
+   struct migration_event
+   {
+      uint16_t index;
+   };
+   EOSIO_REFLECT(migration_event, index)
+
    struct election_event_schedule
    {
       eosio::block_timestamp election_time;
@@ -225,7 +231,8 @@ namespace eden
                               distribution_event_return_excess,
                               distribution_event_fund,
                               distribution_event_end,
-                              distribution_event_return>;
+                              distribution_event_return,
+                              migration_event>;
 
    void push_event(const event& e, eosio::name self);
    void send_events(eosio::name self);

--- a/contracts/eden/include/events.hpp
+++ b/contracts/eden/include/events.hpp
@@ -32,7 +32,7 @@ namespace eden
 
    struct migration_event
    {
-      uint16_t index;
+      varuint32 index;
    };
    EOSIO_REFLECT(migration_event, index)
 

--- a/contracts/eden/include/events.hpp
+++ b/contracts/eden/include/events.hpp
@@ -5,6 +5,7 @@
 #include <eosio/name.hpp>
 #include <eosio/reflection.hpp>
 #include <eosio/time.hpp>
+#include <eosio/varint.hpp>
 #include <variant>
 #include <vector>
 
@@ -32,7 +33,7 @@ namespace eden
 
    struct migration_event
    {
-      varuint32 index;
+      eosio::varuint32 index;
    };
    EOSIO_REFLECT(migration_event, index)
 

--- a/contracts/eden/include/inductions.hpp
+++ b/contracts/eden/include/inductions.hpp
@@ -144,7 +144,6 @@ namespace eden
 
       void check_new_induction(eosio::name invitee, eosio::name inviter) const;
       bool is_valid_induction(const induction& induction) const;
-      void check_valid_induction(const induction& induction) const;
       void validate_profile(const new_member_profile& new_member_profile) const;
       void validate_video(const std::string& video) const;
       void check_valid_endorsers(eosio::name inviter,
@@ -165,6 +164,7 @@ namespace eden
       const induction& get_induction(uint64_t id) const;
       const induction& get_endorsed_induction(eosio::name invitee) const;
       bool has_induction(eosio::name invitee) const;
+      void check_valid_induction(const induction& induction) const;
 
       void initialize_induction(uint64_t id,
                                 eosio::name inviter,

--- a/contracts/eden/include/migrations.hpp
+++ b/contracts/eden/include/migrations.hpp
@@ -19,14 +19,16 @@ namespace eden
    EOSIO_REFLECT(no_migration<0>);
    EOSIO_REFLECT(no_migration<1>);
    EOSIO_REFLECT(no_migration<2>);
-   using migration_variant =
-       std::variant<migrate_auction_v0,
-                    migrate_account_v0,
-                    no_migration<0>,
-                    migrate_member_v0,
-                    no_migration<1>,
-                    // Migration 2 is a no-op to notify history expiring inductions are checked
-                    no_migration<2>>;
+
+   // No-op migration to notify history the fix for checking expired inductions on inductdonate
+   using fix_inductdonate_expiration_check = no_migration<2>;
+
+   using migration_variant = std::variant<migrate_auction_v0,
+                                          migrate_account_v0,
+                                          no_migration<0>,
+                                          migrate_member_v0,
+                                          no_migration<1>,
+                                          fix_inductdonate_expiration_check>;
 
    using migration_singleton = eosio::singleton<"migration"_n, migration_variant>;
 

--- a/contracts/eden/include/migrations.hpp
+++ b/contracts/eden/include/migrations.hpp
@@ -18,11 +18,15 @@ namespace eden
    };
    EOSIO_REFLECT(no_migration<0>);
    EOSIO_REFLECT(no_migration<1>);
-   using migration_variant = std::variant<migrate_auction_v0,
-                                          migrate_account_v0,
-                                          no_migration<0>,
-                                          migrate_member_v0,
-                                          no_migration<1>>;
+   EOSIO_REFLECT(no_migration<2>);
+   using migration_variant =
+       std::variant<migrate_auction_v0,
+                    migrate_account_v0,
+                    no_migration<0>,
+                    migrate_member_v0,
+                    no_migration<1>,
+                    // Migration 2 is a no-op to notify history expiring inductions are checked
+                    no_migration<2>>;
 
    using migration_singleton = eosio::singleton<"migration"_n, migration_variant>;
 

--- a/contracts/eden/src/actions/induct.cpp
+++ b/contracts/eden/src/actions/induct.cpp
@@ -108,6 +108,7 @@ namespace eden
       accounts user_accounts{get_self()};
 
       const auto& induction = inductions.get_induction(id);
+      inductions.check_valid_induction(induction);
       eosio::check(payer == induction.invitee(), "only inductee may donate using this action");
       eosio::check(quantity == globals.get().minimum_donation, "incorrect donation");
       user_accounts.sub_balance(payer, quantity);

--- a/contracts/eden/src/eden-micro-chain.cpp
+++ b/contracts/eden/src/eden-micro-chain.cpp
@@ -217,6 +217,7 @@ struct status
    eosio::block_timestamp nextElection;
    uint16_t electionThreshold = 0;
    uint16_t numElectionParticipants = 0;
+   uint16_t migrationIndex = 0;
 };
 
 struct status_object : public chainbase::object<status_table, status_object>
@@ -1644,6 +1645,12 @@ void logtransfer(const action_context& context,
    }
 }
 
+void handle_event(const eden::migration_event& event)
+{
+   db.status.modify(get_status(),
+                    [&](auto& status) { status.status.migrationIndex = event.index; });
+}
+
 void handle_event(const eden::election_event_schedule& event)
 {
    db.status.modify(get_status(), [&](auto& status) {
@@ -1853,19 +1860,12 @@ void call(void (*f)(const action_context&, Args...),
    std::apply([&](auto&&... args) { f(context, std::move(args)...); }, t);
 }
 
-void remove_expired_inductions(const subchain::eosio_block& block)
+void remove_expired_inductions(const eosio::time_point& block_time, const status& status)
 {
-   auto& idx = db.status.get<by_id>();
-   if (idx.size() < 1)
-      return;  // skip if genesis is not complete
+   if (status.migrationIndex < 5)
+      return;  // skip if migration is not ready to collect expired records
 
-   const auto& status = get_status();
-   if (!status.status.active)
-      return;  // skip if not active
-
-   auto expiration_time =
-       eosio::block_timestamp(block.timestamp).to_time_point().sec_since_epoch() -
-       eden::induction_expiration_secs;
+   auto expiration_time = block_time.sec_since_epoch() - eden::induction_expiration_secs;
 
    auto& index = db.inductions.get<by_createdAt>();
    auto it = index.begin();
@@ -1878,6 +1878,19 @@ void remove_expired_inductions(const subchain::eosio_block& block)
       db.inductions.remove(*it);
       it = next;
    }
+}
+
+void clean_data(const subchain::eosio_block& block)
+{
+   auto& idx = db.status.get<by_id>();
+   if (idx.size() < 1)
+      return;  // skip if genesis is not complete
+
+   const auto& status = get_status();
+   if (!status.status.active)
+      return;  // skip if contract is not active
+
+   remove_expired_inductions(block.timestamp, status.status);
 }
 
 void filter_block(const subchain::eosio_block& block)
@@ -1948,7 +1961,7 @@ void filter_block(const subchain::eosio_block& block)
       }  // for(action)
 
       // garbage collection housekeeping
-      // remove_expired_inductions(block);
+      clean_data(block);
 
       eosio::check(!block_state.in_withdraw && !block_state.in_manual_transfer,
                    "missing transfer notification");

--- a/contracts/eden/src/migrations.cpp
+++ b/contracts/eden/src/migrations.cpp
@@ -1,3 +1,4 @@
+#include <events.hpp>
 #include <migrations.hpp>
 
 namespace eden
@@ -7,15 +8,16 @@ namespace eden
       eosio::check(migration_sing.get().index() == new_value.index(),
                    "Cannot change current migration");
       migration_sing.set(new_value, contract);
+      push_event(migration_event{static_cast<uint16_t>(new_value.index())}, contract);
    }
 
    void migrations::clear_all() { clear_singleton(migration_sing, contract); }
 
    void migrations::init()
    {
-      migration_sing.set(std::variant_alternative_t<std::variant_size_v<migration_variant> - 1,
-                                                    migration_variant>(),
-                         contract);
+      constexpr size_t index = std::variant_size_v<migration_variant> - 1;
+      migration_sing.set(std::variant_alternative_t<index, migration_variant>(), contract);
+      push_event(migration_event{static_cast<uint16_t>(index)}, contract);
    }
 
    uint32_t migrations::migrate_some(uint32_t max_steps)

--- a/contracts/eden/src/migrations.cpp
+++ b/contracts/eden/src/migrations.cpp
@@ -16,7 +16,7 @@ namespace eden
    {
       constexpr size_t index = std::variant_size_v<migration_variant> - 1;
       migration_sing.set(std::variant_alternative_t<index, migration_variant>(), contract);
-      push_event(migration_event{static_cast<varuint32>(index)}, contract);
+      push_event(migration_event{static_cast<eosio::varuint32>(index)}, contract);
    }
 
    uint32_t migrations::migrate_some(uint32_t max_steps)
@@ -42,7 +42,7 @@ namespace eden
              state);
       }
       migration_sing.set(state, contract);
-      push_event(migration_event{static_cast<varuint32>(state.index())}, contract);
+      push_event(migration_event{static_cast<eosio::varuint32>(state.index())}, contract);
       return max_steps;
    }
 }  // namespace eden

--- a/contracts/eden/src/migrations.cpp
+++ b/contracts/eden/src/migrations.cpp
@@ -8,7 +8,6 @@ namespace eden
       eosio::check(migration_sing.get().index() == new_value.index(),
                    "Cannot change current migration");
       migration_sing.set(new_value, contract);
-      push_event(migration_event{static_cast<uint16_t>(new_value.index())}, contract);
    }
 
    void migrations::clear_all() { clear_singleton(migration_sing, contract); }
@@ -17,7 +16,7 @@ namespace eden
    {
       constexpr size_t index = std::variant_size_v<migration_variant> - 1;
       migration_sing.set(std::variant_alternative_t<index, migration_variant>(), contract);
-      push_event(migration_event{static_cast<uint16_t>(index)}, contract);
+      push_event(migration_event{static_cast<varuint32>(index)}, contract);
    }
 
    uint32_t migrations::migrate_some(uint32_t max_steps)
@@ -43,6 +42,7 @@ namespace eden
              state);
       }
       migration_sing.set(state, contract);
+      push_event(migration_event{static_cast<varuint32>(state.index())}, contract);
       return max_steps;
    }
 }  // namespace eden

--- a/contracts/eden/src/migrations.cpp
+++ b/contracts/eden/src/migrations.cpp
@@ -29,6 +29,8 @@ namespace eden
                 max_steps = current_state.migrate_some(contract, max_steps);
                 if (max_steps)
                 {
+                   push_event(migration_event{static_cast<eosio::varuint32>(state.index())},
+                              contract);
                    constexpr std::size_t next_index =
                        boost::mp11::mp_find<migration_variant,
                                             std::decay_t<decltype(current_state)>>::value +
@@ -42,7 +44,6 @@ namespace eden
              state);
       }
       migration_sing.set(state, contract);
-      push_event(migration_event{static_cast<eosio::varuint32>(state.index())}, contract);
       return max_steps;
    }
 }  // namespace eden

--- a/contracts/eden/tests/data/test-election.expected
+++ b/contracts/eden/tests/data/test-election.expected
@@ -1,4 +1,10 @@
 [
+    "migration_event",
+    {
+        "index": 5
+    }
+]
+[
     "set_pool_event",
     {
         "pool": "master",


### PR DESCRIPTION
- check induction is not expired on inductdonate action
- add a no migration to flag the history about this fix
- add a migrationIndex on the microchain status and captures the event
- check for the migrationIndex before cleaning up expired inductions