### PR TITLE
Get UI working with ephemeral chain

### DIFF
--- a/packages/webapp/src/_app/ui/nav-profile.tsx
+++ b/packages/webapp/src/_app/ui/nav-profile.tsx
@@ -5,13 +5,10 @@ import { usePopper } from "react-popper";
 import { IoMdLogIn } from "react-icons/io";
 
 import { MemberStatus } from "_app";
-import {
-    useCurrentMember,
-    useMemberDataFromEdenMembers,
-    useSignOut,
-} from "_app/hooks";
+import { useCurrentMember, useSignOut } from "_app/hooks";
 import { Button, ProfileImage, Text } from "_app/ui";
 import { ROUTES } from "_app/routes";
+import { useMemberByAccountName } from "members/hooks";
 
 import { useUALAccount } from "../eos";
 
@@ -23,20 +20,10 @@ export const NavProfile = ({ location }: Props) => {
     const [ualAccount, _, ualShowModal] = useUALAccount();
     const accountName = ualAccount?.accountName;
 
-    const {
-        data: member,
-        isLoading: isLoadingCurrentMember,
-        isError: isErrorCurrentMember,
-    } = useCurrentMember();
-    const {
-        data: memberData,
-        isLoading: isLoadingMemberData,
-        isError: isErrorMemberData,
-    } = useMemberDataFromEdenMembers(member ? [member] : []);
+    const { data: member } = useCurrentMember();
+    const { data: userProfile } = useMemberByAccountName(member?.account ?? "");
 
     const isActiveMember = member?.status === MemberStatus.ActiveMember;
-
-    const userProfile = memberData?.[0];
 
     if (!ualAccount) {
         return (

--- a/packages/webapp/src/delegates/components/my-delegation.tsx
+++ b/packages/webapp/src/delegates/components/my-delegation.tsx
@@ -12,7 +12,7 @@ import {
     ElectionParticipantChip,
     ElectionState,
 } from "elections";
-import { MembersGrid } from "members";
+import { MembersGrid, useMembersByAccountNames } from "members";
 import { EdenMember, MemberData } from "members/interfaces";
 
 import { ErrorLoadingDelegation } from "./statuses";
@@ -108,19 +108,13 @@ const ChiefDelegates = ({
         .map((chiefQR) => chiefQR.data)
         .filter((el) => Boolean(el));
 
-    const nftTemplateIds = chiefsAsMembers.map(
-        (member) => member!.nft_template_id
-    );
-
     const {
         data: memberData,
         isLoading: isLoadingMemberData,
         isError: isErrorMemberData,
-    } = useQuery({
-        ...queryMembers(1, allChiefAccountNames.length, nftTemplateIds),
-        staleTime: Infinity,
-        enabled: Boolean(chiefsAsMembers?.length),
-    });
+    } = useMembersByAccountNames(
+        chiefsAsMembers.map((chief) => chief!.account)
+    );
 
     const isLoading = isLoadingMemberStats || isLoadingMemberData;
     const isError = isErrorMemberStats || isErrorMemberData;

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -1,11 +1,7 @@
-import {
-    isValidDelegate,
-    useMemberDataFromEdenMembers,
-    useParticipantsInMyCompletedRound,
-} from "_app";
+import { isValidDelegate, useParticipantsInMyCompletedRound } from "_app";
 import { Container, Expander, Text } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
-import { EdenMember, MembersGrid } from "members";
+import { EdenMember, MembersGrid, useMembersByAccountNames } from "members";
 
 import RoundHeader from "./round-header";
 import { VideoUploadButton } from "./video-upload-button";
@@ -18,8 +14,9 @@ export const CompletedRoundSegment = ({
     roundIndex,
 }: CompletedRoundSegmentProps) => {
     const { data } = useParticipantsInMyCompletedRound(roundIndex);
-    const { data: participantsMemberData } = useMemberDataFromEdenMembers(
-        data?.participants
+
+    const { data: participantsMemberData } = useMembersByAccountNames(
+        data?.participants.map((participant) => participant.account)
     );
 
     if (!participantsMemberData || !participantsMemberData.length) return null;

--- a/packages/webapp/src/members/hooks/queries.ts
+++ b/packages/webapp/src/members/hooks/queries.ts
@@ -42,6 +42,16 @@ export const useMembers = () => {
     return { ...result, data: formattedMembers };
 };
 
+export const useMembersByAccountNames = (
+    accountNames: string[] | undefined = []
+) => {
+    const { data: allMembers, ...memberQueryMetaData } = useMembers();
+    const members = allMembers.filter((member) =>
+        accountNames.includes(member.account)
+    );
+    return { data: members, ...memberQueryMetaData };
+};
+
 export const useMemberByAccountName = (account: string) => {
     const result = useBoxQuery<MembersQuery>(`{
         members(ge: "${account}", le: "${account}") {

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -5,12 +5,11 @@ import {
     SideNavLayout,
     useCurrentElection,
     useElectionState,
-    useMemberDataFromEdenMembers,
     useMyDelegation,
 } from "_app";
 import { Container, Heading, LoadingContainer, Text } from "_app/ui";
 import { ElectionStatus } from "elections/interfaces";
-import { MemberGateContainer } from "members";
+import { MemberGateContainer, useMembersByAccountNames } from "members";
 import {
     ErrorLoadingDelegation,
     ElectionInProgress,
@@ -45,7 +44,9 @@ export const DelegatesPage = () => {
         data: myDelegationMemberData,
         isLoading: isLoadingMemberData,
         isError: isErrorMemberData,
-    } = useMemberDataFromEdenMembers(myDelegation);
+    } = useMembersByAccountNames(
+        myDelegation?.map((delegate) => delegate.account)
+    );
 
     const isLoading =
         isLoadingCurrentElection ||


### PR DESCRIPTION
Refactoring areas of UI dependence on AtomicHub APIs for member data to instead use subchain. For example, the account profile component in the nav bars, My Delegation page, and ongoing election UI was broken when running on the ephemeral chain. This fixes that.

While I need to finish testing a full election before I know everything is working properly, this does represent important progress. So I'll go ahead and submit this for review.

Once UI-working-with-ephemeral-chain baseline is met, we can get into deeper refactoring.