### PR TITLE
Separate out NFT data from Member data

### DIFF
--- a/packages/webapp/src/_app/hooks/box-queries.ts
+++ b/packages/webapp/src/_app/hooks/box-queries.ts
@@ -7,9 +7,9 @@ import dayjs from "dayjs";
 import { assetFromString } from "_app";
 import {
     formatMembersQueryNodeAsMemberNFT,
-    MemberNFT,
     MEMBER_DATA_FRAGMENT,
 } from "members";
+import { MemberNFT } from "nfts/interfaces";
 
 export interface ElectionStatusQuery {
     status: {

--- a/packages/webapp/src/_app/hooks/box-queries.ts
+++ b/packages/webapp/src/_app/hooks/box-queries.ts
@@ -6,8 +6,8 @@ import dayjs from "dayjs";
 
 import { assetFromString } from "_app";
 import {
-    formatQueriedMemberData,
-    MemberData,
+    formatMembersQueryNodeAsMemberNFT,
+    MemberNFT,
     MEMBER_DATA_FRAGMENT,
 } from "members";
 
@@ -41,8 +41,8 @@ export interface RoundBasicQueryData {
 }
 
 export interface RoundForUserVotingQueryData extends RoundBasicQueryData {
-    candidate?: MemberData;
-    winner?: MemberData;
+    candidate?: MemberNFT;
+    winner?: MemberNFT;
     video: string;
 }
 
@@ -116,8 +116,12 @@ export const useCurrentMemberElectionVotingData = (
                     votingFinished: voteNode.group.round.votingFinished,
                     resultsAvailable: voteNode.group.round.resultsAvailable,
                     numGroups: voteNode.group.round.numGroups,
-                    candidate: formatQueriedMemberData(voteNode.candidate),
-                    winner: formatQueriedMemberData(voteNode.group.winner),
+                    candidate: formatMembersQueryNodeAsMemberNFT(
+                        voteNode.candidate
+                    ),
+                    winner: formatMembersQueryNodeAsMemberNFT(
+                        voteNode.group.winner
+                    ),
                     video: voteNode.video,
                 })) || [];
         }
@@ -127,13 +131,13 @@ export const useCurrentMemberElectionVotingData = (
 };
 
 export interface VoteQueryData {
-    voter: MemberData;
-    candidate?: MemberData;
+    voter: MemberNFT;
+    candidate?: MemberNFT;
     video: string;
 }
 
 export interface RoundGroupQueryData {
-    winner?: MemberData;
+    winner?: MemberNFT;
     votes: VoteQueryData[];
 }
 
@@ -217,15 +221,15 @@ const mapQueriedRounds = (queriedRoundsEdges: any) =>
 
 const mapQueriedRoundsGroups = (queriedRoundsGroupsEdges: any) =>
     queriedRoundsGroupsEdges?.map(({ node: groupNode }: any) => ({
-        winner: formatQueriedMemberData(groupNode.winner),
+        winner: formatMembersQueryNodeAsMemberNFT(groupNode.winner),
         votes: mapQueriedGroupVotes(groupNode.votes),
     })) || [];
 
 const mapQueriedGroupVotes = (votes: any) => {
     return (
         votes?.map((vote: any) => ({
-            voter: formatQueriedMemberData(vote.voter),
-            candidate: formatQueriedMemberData(vote.candidate),
+            voter: formatMembersQueryNodeAsMemberNFT(vote.voter),
+            candidate: formatMembersQueryNodeAsMemberNFT(vote.candidate),
             video: vote.video,
         })) || []
     );

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -8,7 +8,7 @@ import {
     getMembersStats,
     MemberNFT,
     MemberStats,
-    useMembersByAccountNames,
+    useMembersByAccountNamesAsMemberNFTs,
 } from "members";
 import { getCommunityGlobals, getTokenBalanceForAccount } from "_app/api";
 import {
@@ -423,7 +423,7 @@ export const useMemberDataFromVoteData = (voteData?: VoteData[]) => {
         .map((res) => res.data as EdenMember)
         .map((member) => member.account);
 
-    const memberDataRes = useMembersByAccountNames(accountNames);
+    const memberDataRes = useMembersByAccountNamesAsMemberNFTs(accountNames);
 
     return {
         ...memberDataRes,

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -6,7 +6,6 @@ import {
     getMembers,
     getTreasuryStats,
     getMembersStats,
-    MemberNFT,
     MemberStats,
     useMembersByAccountNamesAsMemberNFTs,
 } from "members";
@@ -41,6 +40,7 @@ import {
     ElectionCompletedRound,
     VoteData,
 } from "elections/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 import { EncryptionScope, getEncryptedData } from "encryption/api";
 import { TableQueryOptions } from "_app/eos/interfaces";
 

--- a/packages/webapp/src/_app/hooks/queries.ts
+++ b/packages/webapp/src/_app/hooks/queries.ts
@@ -6,7 +6,7 @@ import {
     getMembers,
     getTreasuryStats,
     getMembersStats,
-    MemberData,
+    MemberNFT,
     MemberStats,
     useMembersByAccountNames,
 } from "members";
@@ -150,7 +150,7 @@ export const queryCommunityGlobals = {
 };
 
 export const queryOngoingElectionData = (
-    votingMemberData?: MemberData[],
+    votingMemberData?: MemberNFT[],
     currentElection?: CurrentElection,
     myDelegation?: EdenMember[],
     currentMember?: EdenMember
@@ -430,7 +430,7 @@ export const useMemberDataFromVoteData = (voteData?: VoteData[]) => {
         isLoading: memberDataRes.isLoading || isLoading,
         isError: memberDataRes.isError || isFetchError,
         isSuccess: areQueriesComplete,
-    } as UseQueryResult<MemberData[], Error>;
+    } as UseQueryResult<MemberNFT[], Error>;
 };
 
 export const useEncryptedData = (scope: EncryptionScope, id: string) =>

--- a/packages/webapp/src/_app/ui/generic-member-chip.tsx
+++ b/packages/webapp/src/_app/ui/generic-member-chip.tsx
@@ -1,8 +1,7 @@
 import { DelegateBadge, ProfileImage } from "_app/ui";
-import { MemberData } from "members/interfaces";
 
 interface Props {
-    member: MemberData;
+    imageUrl: string;
     isDelegate?: boolean;
     actionComponent?: React.ReactNode;
     contentComponent: React.ReactNode;
@@ -12,7 +11,7 @@ interface Props {
 }
 
 export const GenericMemberChip = ({
-    member,
+    imageUrl,
     isDelegate, // TODO: depend on info in member for this
     onClickChip,
     onClickProfileImage,
@@ -33,7 +32,7 @@ export const GenericMemberChip = ({
             >
                 <div className="flex space-x-2.5">
                     <ProfileImage
-                        imageCid={member.image}
+                        imageUrl={imageUrl}
                         badge={isDelegate && <DelegateBadge size={11} />}
                         onClick={onClickProfileImage || onClickChip}
                     />

--- a/packages/webapp/src/_app/ui/nav-profile.tsx
+++ b/packages/webapp/src/_app/ui/nav-profile.tsx
@@ -64,7 +64,7 @@ export const NavProfile = ({ location }: Props) => {
                 <div className={CONTAINER_CLASS}>
                     <div className="cursor-pointer">
                         <ProfileImage
-                            imageCid={member?.profile?.image.cid}
+                            imageUrl={member?.profile?.image.url}
                             size={40}
                         />
                     </div>

--- a/packages/webapp/src/_app/ui/profile-image.tsx
+++ b/packages/webapp/src/_app/ui/profile-image.tsx
@@ -1,30 +1,28 @@
 import React, { CSSProperties } from "react";
 import { FaSpinner } from "react-icons/fa";
 
-import { ipfsUrl } from "_app";
-
 import { Image } from "./image";
 
 interface ProfileImageProps {
-    imageCid?: string;
+    imageUrl?: string;
     badge?: React.ReactNode;
     onClick?: (e: React.MouseEvent) => void;
     size?: number;
 }
 
 export const ProfileImage = ({
-    imageCid,
+    imageUrl,
     badge,
     onClick,
     size = 56,
 }: ProfileImageProps) => {
     const imageClass = "rounded-full object-cover shadow";
     const imageSize = { height: size, width: size };
-    if (imageCid) {
+    if (imageUrl) {
         return (
             <div className="relative group" onClick={onClick}>
                 <Image
-                    src={ipfsUrl(imageCid)}
+                    src={imageUrl}
                     fallbackImage="/images/avatars/fallback/avatar-6.svg"
                     loaderComponent={<ImageLoader style={imageSize} />}
                     className={imageClass}

--- a/packages/webapp/src/delegates/components/my-delegation.tsx
+++ b/packages/webapp/src/delegates/components/my-delegation.tsx
@@ -8,7 +8,8 @@ import {
     ElectionState,
 } from "elections";
 import { MembersGrid, useMembersByAccountNamesAsMemberNFTs } from "members";
-import { EdenMember, MemberNFT } from "members/interfaces";
+import { EdenMember } from "members/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 
 import { ErrorLoadingDelegation } from "./statuses";
 import { LevelHeading } from "./level-heading";

--- a/packages/webapp/src/delegates/components/my-delegation.tsx
+++ b/packages/webapp/src/delegates/components/my-delegation.tsx
@@ -1,11 +1,6 @@
 import React from "react";
-import { useQuery } from "react-query";
 
-import {
-    useMemberStats,
-    useMemberListByAccountNames,
-    queryMembers,
-} from "_app";
+import { useMemberStats, useMemberListByAccountNames } from "_app";
 import { LoadingContainer } from "_app/ui";
 import {
     DelegateChip,
@@ -13,7 +8,7 @@ import {
     ElectionState,
 } from "elections";
 import { MembersGrid, useMembersByAccountNames } from "members";
-import { EdenMember, MemberData } from "members/interfaces";
+import { EdenMember, MemberNFT } from "members/interfaces";
 
 import { ErrorLoadingDelegation } from "./statuses";
 import { LevelHeading } from "./level-heading";
@@ -21,7 +16,7 @@ import { MyDelegationArrow } from "./arrow-container";
 
 interface Props {
     electionState?: ElectionState;
-    members: MemberData[];
+    members: MemberNFT[];
     myDelegation: EdenMember[];
 }
 
@@ -146,7 +141,7 @@ const ChiefDelegates = ({
                     Chief Delegates
                 </LevelHeading>
                 <MembersGrid members={memberData}>
-                    {(chiefDelegate) => {
+                    {(chiefDelegate: MemberNFT) => {
                         if (!chiefDelegate) return null;
                         return (
                             <DelegateChip

--- a/packages/webapp/src/delegates/components/my-delegation.tsx
+++ b/packages/webapp/src/delegates/components/my-delegation.tsx
@@ -7,7 +7,7 @@ import {
     ElectionParticipantChip,
     ElectionState,
 } from "elections";
-import { MembersGrid, useMembersByAccountNames } from "members";
+import { MembersGrid, useMembersByAccountNamesAsMemberNFTs } from "members";
 import { EdenMember, MemberNFT } from "members/interfaces";
 
 import { ErrorLoadingDelegation } from "./statuses";
@@ -107,7 +107,7 @@ const ChiefDelegates = ({
         data: memberData,
         isLoading: isLoadingMemberData,
         isError: isErrorMemberData,
-    } = useMembersByAccountNames(
+    } = useMembersByAccountNamesAsMemberNFTs(
         chiefsAsMembers.map((chief) => chief!.account)
     );
 
@@ -126,11 +126,11 @@ const ChiefDelegates = ({
     const headChiefAsEdenMember = chiefsAsMembers.find(
         (d) => d?.account === electionState.lead_representative
     );
-    const headChiefAsMemberData = memberData.find(
+    const headChiefAsMemberNFT = memberData.find(
         (d) => d?.account === electionState.lead_representative
     );
 
-    if (!headChiefAsEdenMember || !headChiefAsMemberData) {
+    if (!headChiefAsEdenMember || !headChiefAsMemberNFT) {
         return <ErrorLoadingDelegation />;
     }
 
@@ -157,7 +157,7 @@ const ChiefDelegates = ({
             <div className="mb-16">
                 <LevelHeading>Head Chief</LevelHeading>
                 <DelegateChip
-                    member={headChiefAsMemberData}
+                    member={headChiefAsMemberNFT}
                     level={headChiefAsEdenMember.election_rank + 1}
                     delegateTitle=""
                 />

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -22,7 +22,8 @@ import {
     queryParticipantsInCompletedRound,
     TABLE_INDEXES,
 } from "_app";
-import { EdenMember, MemberNFT, VoteDataQueryOptionsByField } from "members";
+import { EdenMember, VoteDataQueryOptionsByField } from "members";
+import { MemberNFT } from "nfts/interfaces";
 import {
     ActiveStateConfigType,
     CONFIG_SORTITION_ROUND_DEFAULTS,

--- a/packages/webapp/src/elections/api/eden-contract.ts
+++ b/packages/webapp/src/elections/api/eden-contract.ts
@@ -20,10 +20,9 @@ import {
     queryMemberByAccountName,
     queryMembers,
     queryParticipantsInCompletedRound,
-    queryVoteDataRow,
     TABLE_INDEXES,
 } from "_app";
-import { EdenMember, MemberData, VoteDataQueryOptionsByField } from "members";
+import { EdenMember, MemberNFT, VoteDataQueryOptionsByField } from "members";
 import {
     ActiveStateConfigType,
     CONFIG_SORTITION_ROUND_DEFAULTS,
@@ -317,11 +316,9 @@ const getMemberDataFromEdenMemberList = async (memberList: EdenMember[]) => {
         nftTemplateIds
     );
 
-    return await queryClient.fetchQuery<MemberData[], Error>(
-        queryKey,
-        queryFn,
-        { staleTime: Infinity }
-    );
+    return await queryClient.fetchQuery<MemberNFT[], Error>(queryKey, queryFn, {
+        staleTime: Infinity,
+    });
 };
 const getParticipantsOfCompletedRounds = async (myDelegation: EdenMember[]) => {
     const pCompletedRounds = myDelegation.map(
@@ -369,7 +366,7 @@ const getParticipantsOfCompletedRounds = async (myDelegation: EdenMember[]) => {
  * @param {string} author - The author of the book.
  */
 export const getOngoingElectionData = async (
-    votingMemberData: MemberData[] = [],
+    votingMemberData: MemberNFT[] = [],
     currentElection?: CurrentElection,
     myDelegation: EdenMember[] = [],
     loggedInMember?: EdenMember

--- a/packages/webapp/src/elections/api/fixtures.ts
+++ b/packages/webapp/src/elections/api/fixtures.ts
@@ -4,7 +4,7 @@ import {
     ElectionStatus,
     VoteData,
 } from "elections/interfaces";
-import { MemberData } from "members";
+import { MemberNFT } from "members";
 import {
     getFixtureEdenMember,
     getFixtureMemberData,
@@ -163,7 +163,7 @@ export const fixtureCompletedRounds = [
         // delegate: undefined,
     },
 ];
-export const fixtureOngoingRound = (votingMemberData: MemberData[]) => ({
+export const fixtureOngoingRound = (votingMemberData: MemberNFT[]) => ({
     // participants: [],
     // participantsMemberData: [],
     // participants: membersInOngoingRound,

--- a/packages/webapp/src/elections/api/fixtures.ts
+++ b/packages/webapp/src/elections/api/fixtures.ts
@@ -4,7 +4,7 @@ import {
     ElectionStatus,
     VoteData,
 } from "elections/interfaces";
-import { MemberNFT } from "members";
+import { MemberNFT } from "nfts/interfaces";
 import {
     getFixtureEdenMember,
     getFixtureMemberData,

--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -9,9 +9,9 @@ import {
 } from "_app";
 import { ROUTES } from "_app/routes";
 import { GenericMemberChip, OpensInNewTabIcon } from "_app/ui";
-import { MemberNFT } from "members/interfaces";
 import { getValidSocialLink } from "members/helpers/social-links";
 import { MemberChipTelegramLink } from "members/components/member-chip-components";
+import { MemberNFT } from "nfts/interfaces";
 
 interface VotingMemberChipProps {
     member: MemberNFT;

--- a/packages/webapp/src/elections/components/election-member-chips.tsx
+++ b/packages/webapp/src/elections/components/election-member-chips.tsx
@@ -9,12 +9,12 @@ import {
 } from "_app";
 import { ROUTES } from "_app/routes";
 import { GenericMemberChip, OpensInNewTabIcon } from "_app/ui";
-import { MemberData } from "members/interfaces";
+import { MemberNFT } from "members/interfaces";
 import { getValidSocialLink } from "members/helpers/social-links";
 import { MemberChipTelegramLink } from "members/components/member-chip-components";
 
 interface VotingMemberChipProps {
-    member: MemberData;
+    member: MemberNFT;
     onSelect?: () => void;
     isSelected?: boolean;
     hasCurrentMembersVote?: boolean;
@@ -47,7 +47,7 @@ export const VotingMemberChip = ({
 
     return (
         <GenericMemberChip
-            member={member}
+            imageUrl={ipfsUrl(member.image)}
             isDelegate={isDelegate}
             contentComponent={
                 <div
@@ -137,7 +137,7 @@ const getDelegateLevelDescription = (
 };
 
 interface DelegateChipProps {
-    member?: MemberData;
+    member?: MemberNFT;
     level?: number;
     delegateTitle?: string;
     electionVideoCid?: string;
@@ -160,7 +160,7 @@ export const DelegateChip = ({
 );
 
 interface ElectionParticipantChipProps {
-    member?: MemberData;
+    member?: MemberNFT;
     delegateLevel?: string;
     isDelegate?: boolean;
     electionVideoCid?: string;
@@ -196,7 +196,7 @@ export const ElectionParticipantChip = ({
 
     return (
         <GenericMemberChip
-            member={member}
+            imageUrl={ipfsUrl(member.image)}
             isDelegate={isDelegate || Boolean(delegateLevel)} // TODO: This will be inferred from member
             contentComponent={
                 <div className="flex-1 flex flex-col justify-center">

--- a/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
@@ -9,7 +9,7 @@ import {
 } from "_app/hooks/queries";
 import { Container, Expander, Heading, Loader, Text } from "_app/ui";
 import { DelegateChip, ErrorLoadingElection } from "elections";
-import { MembersGrid } from "members";
+import { MemberNFT, MembersGrid } from "members";
 import { VideoUploadButton } from "./video-upload-button";
 
 import RoundHeader from "./round-header";
@@ -97,7 +97,7 @@ export const ChiefsRoundSegment = ({
                 </Text>
             </Container>
             <MembersGrid members={members}>
-                {(member) => (
+                {(member: MemberNFT) => (
                     <DelegateChip
                         key={`${member.account}-chief-delegate`}
                         member={member}

--- a/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/chiefs-round-segment.tsx
@@ -9,10 +9,11 @@ import {
 } from "_app/hooks/queries";
 import { Container, Expander, Heading, Loader, Text } from "_app/ui";
 import { DelegateChip, ErrorLoadingElection } from "elections";
-import { MemberNFT, MembersGrid } from "members";
-import { VideoUploadButton } from "./video-upload-button";
+import { MembersGrid } from "members";
+import { MemberNFT } from "nfts/interfaces";
 
 import RoundHeader from "./round-header";
+import { VideoUploadButton } from "./video-upload-button";
 
 interface RoundSegmentProps {
     roundEndTime: Dayjs;

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -5,7 +5,7 @@ import {
     EdenMember,
     MemberNFT,
     MembersGrid,
-    useMembersByAccountNames,
+    useMembersByAccountNamesAsMemberNFTs,
 } from "members";
 
 import RoundHeader from "./round-header";
@@ -20,7 +20,9 @@ export const CompletedRoundSegment = ({
 }: CompletedRoundSegmentProps) => {
     const { data } = useParticipantsInMyCompletedRound(roundIndex);
 
-    const { data: participantsMemberData } = useMembersByAccountNames(
+    const {
+        data: participantsMemberData,
+    } = useMembersByAccountNamesAsMemberNFTs(
         data?.participants.map((participant) => participant.account)
     );
 

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -1,7 +1,12 @@
 import { isValidDelegate, useParticipantsInMyCompletedRound } from "_app";
 import { Container, Expander, Text } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
-import { EdenMember, MembersGrid, useMembersByAccountNames } from "members";
+import {
+    EdenMember,
+    MemberNFT,
+    MembersGrid,
+    useMembersByAccountNames,
+} from "members";
 
 import RoundHeader from "./round-header";
 import { VideoUploadButton } from "./video-upload-button";
@@ -31,7 +36,7 @@ export const CompletedRoundSegment = ({
             type="inactive"
         >
             <MembersGrid members={participantsMemberData}>
-                {(member) => {
+                {(member: MemberNFT) => {
                     if (member.account === commonDelegate?.account) {
                         return (
                             <ElectionParticipantChip

--- a/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/completed-round-segment.tsx
@@ -3,10 +3,10 @@ import { Container, Expander, Text } from "_app/ui";
 import { ElectionParticipantChip } from "elections";
 import {
     EdenMember,
-    MemberNFT,
     MembersGrid,
     useMembersByAccountNamesAsMemberNFTs,
 } from "members";
+import { MemberNFT } from "nfts/interfaces";
 
 import RoundHeader from "./round-header";
 import { VideoUploadButton } from "./video-upload-button";

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-voting-panel.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-voting-panel.tsx
@@ -8,8 +8,8 @@ import {
     useCurrentMember,
 } from "_app/hooks/queries";
 import { Button, Container } from "_app/ui";
-import { MemberNFT } from "members/interfaces";
 import { ActiveStateConfigType, VoteData } from "elections/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 
 import { setVote } from "../../../transactions";
 import { VideoUploadButton } from "../video-upload-button";

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-voting-panel.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-voting-panel.tsx
@@ -8,7 +8,7 @@ import {
     useCurrentMember,
 } from "_app/hooks/queries";
 import { Button, Container } from "_app/ui";
-import { MemberData } from "members/interfaces";
+import { MemberNFT } from "members/interfaces";
 import { ActiveStateConfigType, VoteData } from "elections/interfaces";
 
 import { setVote } from "../../../transactions";
@@ -16,7 +16,7 @@ import { VideoUploadButton } from "../video-upload-button";
 import VotingRoundParticipants from "./voting-round-participants";
 
 interface ParticipantsVotingPanelProps {
-    members?: MemberData[];
+    members?: MemberNFT[];
     voteData: VoteData[];
     roundIndex: number;
     electionConfig?: ActiveStateConfigType;
@@ -28,7 +28,7 @@ export const ParticipantsVotingPanel = ({
     roundIndex,
     electionConfig,
 }: ParticipantsVotingPanelProps) => {
-    const [selectedMember, setSelected] = useState<MemberData | null>(null);
+    const [selectedMember, setSelected] = useState<MemberNFT | null>(null);
     const [isSubmittingVote, setIsSubmittingVote] = useState<boolean>(false);
 
     const queryClient = useQueryClient();
@@ -106,9 +106,9 @@ export const ParticipantsVotingPanel = ({
 export default ParticipantsVotingPanel;
 
 interface VoteButtonProps {
-    selectedMember: MemberData | null;
+    selectedMember: MemberNFT | null;
     isSubmittingVote: boolean;
-    userVotingFor?: MemberData;
+    userVotingFor?: MemberNFT;
     onSubmitVote: () => Promise<void>;
 }
 

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-waiting-panel.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-waiting-panel.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { MemberData } from "members/interfaces";
+
+import { MemberNFT } from "members/interfaces";
 import { ElectionParticipantChip } from "elections";
 
 interface ParticipantsWaitingPanelProps {
-    members?: MemberData[];
+    members?: MemberNFT[];
     roundIndex: number;
 }
 

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-waiting-panel.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/participants-waiting-panel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { MemberNFT } from "members/interfaces";
 import { ElectionParticipantChip } from "elections";
+import { MemberNFT } from "nfts/interfaces";
 
 interface ParticipantsWaitingPanelProps {
     members?: MemberNFT[];

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/voting-round-participants.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/voting-round-participants.tsx
@@ -1,13 +1,14 @@
 import { Flipper, Flipped } from "react-flip-toolkit";
+
 import { VotingMemberChip } from "elections";
 import { VoteData } from "elections/interfaces";
-import { MemberData } from "members/interfaces";
+import { MemberNFT } from "members/interfaces";
 
 interface VotingRoundParticipantsProps {
-    members?: MemberData[];
+    members?: MemberNFT[];
     voteData: VoteData[];
-    selectedMember: MemberData | null;
-    onSelectMember: (member: MemberData) => void;
+    selectedMember: MemberNFT | null;
+    onSelectMember: (member: MemberNFT) => void;
     userVotingFor?: string;
 }
 
@@ -18,7 +19,7 @@ const VotingRoundParticipants = ({
     onSelectMember,
     userVotingFor,
 }: VotingRoundParticipantsProps) => {
-    const getVoteCountForMember = (member: MemberData) => {
+    const getVoteCountForMember = (member: MemberNFT) => {
         return voteData.filter((vd) => vd.candidate === member.account).length;
     };
 
@@ -26,7 +27,7 @@ const VotingRoundParticipants = ({
         (a, b) => getVoteCountForMember(b) - getVoteCountForMember(a)
     );
 
-    const selectMember = (member: MemberData) => {
+    const selectMember = (member: MemberNFT) => {
         if (member.account === selectedMember?.account) return;
         onSelectMember(member);
     };

--- a/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/voting-round-participants.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/ongoing-round/voting-round-participants.tsx
@@ -2,7 +2,7 @@ import { Flipper, Flipped } from "react-flip-toolkit";
 
 import { VotingMemberChip } from "elections";
 import { VoteData } from "elections/interfaces";
-import { MemberNFT } from "members/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 
 interface VotingRoundParticipantsProps {
     members?: MemberNFT[];

--- a/packages/webapp/src/elections/interfaces.ts
+++ b/packages/webapp/src/elections/interfaces.ts
@@ -1,4 +1,5 @@
-import { EdenMember, MemberNFT } from "members";
+import { EdenMember } from "members/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 
 const NUM_PARTICIPANTS_IN_SORTITION_ROUND = 1;
 const MAX_PARTICIPANTS_IN_SORTITION_ROUND = 13;

--- a/packages/webapp/src/elections/interfaces.ts
+++ b/packages/webapp/src/elections/interfaces.ts
@@ -1,4 +1,4 @@
-import { EdenMember, MemberData } from "members";
+import { EdenMember, MemberNFT } from "members";
 
 const NUM_PARTICIPANTS_IN_SORTITION_ROUND = 1;
 const MAX_PARTICIPANTS_IN_SORTITION_ROUND = 13;
@@ -105,7 +105,7 @@ export enum RoundStage {
 
 export interface ElectionCompletedRound {
     participants: EdenMember[]; // .length will be number of participants and empty if no round happened
-    participantsMemberData?: MemberData[];
+    participantsMemberData?: MemberNFT[];
     didReachConsensus?: boolean;
     delegate?: EdenMember;
 }
@@ -120,6 +120,6 @@ export interface Election {
     ongoingRound: {
         roundIndex?: number;
         participants: EdenMember[];
-        participantsMemberData: MemberData[];
+        participantsMemberData: MemberNFT[];
     };
 }

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
@@ -1,18 +1,10 @@
 import { FormEvent, useState } from "react";
 
-import {
-    useFormFields,
-    Form,
-    Heading,
-    Button,
-    HelpLink,
-    handleFileChange,
-    Image,
-    ipfsUrl,
-} from "_app";
 import { edenContractAccount, validUploadActions } from "config";
-import { EdenNftSocialHandles } from "nfts";
+import { useFormFields, handleFileChange, ipfsUrl } from "_app";
+import { Form, Heading, Button, HelpLink, Image } from "_app/ui";
 import { NewMemberProfile } from "inductions";
+import { MemberSocialHandles } from "members/interfaces";
 
 interface Props {
     newMemberProfile: NewMemberProfile;
@@ -49,7 +41,7 @@ export const InductionProfileForm = ({
 
         const socialHandles = { ...socialFields };
         Object.keys(socialHandles).forEach((keyString) => {
-            const key = keyString as keyof EdenNftSocialHandles;
+            const key = keyString as keyof MemberSocialHandles;
             if (!socialHandles[key]) delete socialHandles[key];
         });
 
@@ -252,9 +244,7 @@ const ProfileImage = ({ image }: { image?: File | string }) => {
     );
 };
 
-const convertNewMemberProfileSocial = (
-    social: string
-): EdenNftSocialHandles => {
+const convertNewMemberProfileSocial = (social: string): MemberSocialHandles => {
     const socialHandles = JSON.parse(social || "{}");
     return {
         eosCommunity: socialHandles.eosCommunity || "",

--- a/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
+++ b/packages/webapp/src/inductions/components/induction-journeys/invitee/profile-form.tsx
@@ -8,6 +8,7 @@ import {
     HelpLink,
     handleFileChange,
     Image,
+    ipfsUrl,
 } from "_app";
 import { edenContractAccount, validUploadActions } from "config";
 import { EdenNftSocialHandles } from "nfts";
@@ -235,8 +236,8 @@ const ProfileImage = ({ image }: { image?: File | string }) => {
         );
 
     let imageUrl: string;
-    if (typeof image === "string") {
-        imageUrl = `https://ipfs.io/ipfs/${image}`;
+    if (typeof image == "string") {
+        imageUrl = ipfsUrl(image);
     } else {
         imageUrl = URL.createObjectURL(image);
     }

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -1,5 +1,6 @@
-import { EdenMember, MemberNFT, MemberStats } from "members";
 import { ElectionParticipationStatus, MemberStatus } from "_app/api/interfaces";
+import { EdenMember, MemberStats } from "members";
+import { MemberNFT } from "nfts/interfaces";
 
 export const fixtureEdenMembers: EdenMember[] = [
     {

--- a/packages/webapp/src/members/api/fixtures.ts
+++ b/packages/webapp/src/members/api/fixtures.ts
@@ -1,4 +1,4 @@
-import { EdenMember, MemberData, MemberStats } from "members";
+import { EdenMember, MemberNFT, MemberStats } from "members";
 import { ElectionParticipationStatus, MemberStatus } from "_app/api/interfaces";
 
 export const fixtureEdenMembers: EdenMember[] = [
@@ -149,7 +149,7 @@ export const fixtureEdenMembers: EdenMember[] = [
     },
 ];
 
-export const fixtureMemberData: MemberData[] = [
+export const fixtureMemberData: MemberNFT[] = [
     {
         templateId: 147800,
         name: "Alice",
@@ -484,5 +484,5 @@ export const fixtureEdenMembersInGroup = (
 
 export const getFixtureEdenMember = (memberAccount: string): EdenMember =>
     fixtureEdenMembers.find((member) => member.account === memberAccount)!;
-export const getFixtureMemberData = (memberAccount: string): MemberData =>
+export const getFixtureMemberData = (memberAccount: string): MemberNFT =>
     fixtureMemberData.find((member) => member.account === memberAccount)!;

--- a/packages/webapp/src/members/api/members.ts
+++ b/packages/webapp/src/members/api/members.ts
@@ -7,7 +7,7 @@ import {
     TemplateData,
 } from "nfts/interfaces";
 
-import { Member, MemberData } from "../interfaces";
+import { Member, MemberNFT } from "../interfaces";
 import { fixtureMemberData } from "./fixtures";
 
 export const getMembers = async (
@@ -16,7 +16,7 @@ export const getMembers = async (
     ids: string[] = [],
     sortField = "created",
     order = "asc"
-): Promise<MemberData[]> => {
+): Promise<MemberNFT[]> => {
     if (devUseFixtureData) {
         let data = fixtureMemberData;
         if (ids.length) {
@@ -33,14 +33,14 @@ export const getMembers = async (
 export const getNewMembers = async (
     page?: number,
     limit?: number
-): Promise<MemberData[]> => {
+): Promise<MemberNFT[]> => {
     const data = await getAuctions(edenContractAccount, undefined, page, limit);
     return data.map(convertAtomicAssetToMemberWithSalesData);
 };
 
-export const getCollection = async (account: string): Promise<MemberData[]> => {
+export const getCollection = async (account: string): Promise<MemberNFT[]> => {
     const assets = await getAccountCollection(account);
-    const members: MemberData[] = assets.map(convertAtomicAssetToMember);
+    const members: MemberNFT[] = assets.map(convertAtomicAssetToMember);
     const assetsOnAuction = await getAuctions(account);
     assetsOnAuction
         .map(convertAtomicAssetToMemberWithSalesData)
@@ -48,7 +48,7 @@ export const getCollection = async (account: string): Promise<MemberData[]> => {
     return members.sort((a, b) => a.createdAt - b.createdAt);
 };
 
-export const memberDataDefaults: MemberData = {
+export const memberNFTDefaults: MemberNFT = {
     templateId: 0,
     name: "",
     image: "",
@@ -80,8 +80,8 @@ export const memberDefaults: Member = {
     participatingInElection: false,
 };
 
-const convertAtomicTemplateToMember = (data: TemplateData): MemberData => ({
-    ...memberDataDefaults,
+const convertAtomicTemplateToMember = (data: TemplateData): MemberNFT => ({
+    ...memberNFTDefaults,
     templateId: parseInt(data.template_id),
     createdAt: parseInt(data.created_at_time),
     name: data.immutable_data.name,
@@ -93,7 +93,7 @@ const convertAtomicTemplateToMember = (data: TemplateData): MemberData => ({
     socialHandles: parseSocial(data.immutable_data.social || "{}"),
 });
 
-const convertAtomicAssetToMember = (data: AssetData): MemberData => ({
+const convertAtomicAssetToMember = (data: AssetData): MemberNFT => ({
     ...convertAtomicTemplateToMember(data.template),
     assetData: {
         assetId: data.asset_id,
@@ -104,7 +104,7 @@ const convertAtomicAssetToMember = (data: AssetData): MemberData => ({
 
 const convertAtomicAssetToMemberWithSalesData = (
     data: AuctionableTemplateData
-): MemberData => {
+): MemberNFT => {
     const member = convertAtomicTemplateToMember(data);
     member.assetData = {
         assetId: data.assetId,

--- a/packages/webapp/src/members/api/members.ts
+++ b/packages/webapp/src/members/api/members.ts
@@ -3,12 +3,12 @@ import { getAccountCollection, getAuctions, getTemplates } from "nfts/api";
 import {
     AssetData,
     AuctionableTemplateData,
-    EdenNftSocialHandles,
+    MemberNFT,
     TemplateData,
 } from "nfts/interfaces";
 
-import { Member, MemberNFT } from "../interfaces";
 import { fixtureMemberData } from "./fixtures";
+import { Member, MemberSocialHandles } from "../interfaces";
 
 export const getMembers = async (
     page: number,
@@ -120,7 +120,7 @@ const convertAtomicAssetToMemberWithSalesData = (
     return member;
 };
 
-const parseSocial = (socialHandlesJsonString: string): EdenNftSocialHandles => {
+const parseSocial = (socialHandlesJsonString: string): MemberSocialHandles => {
     try {
         return JSON.parse(socialHandlesJsonString);
     } catch (e) {

--- a/packages/webapp/src/members/components/home/members-list.tsx
+++ b/packages/webapp/src/members/components/home/members-list.tsx
@@ -7,7 +7,8 @@ import {
 } from "react-virtualized";
 
 import { LoadingContainer, MessageContainer } from "_app/ui";
-import { Member, MemberChip, MemberNFT, useMembersWithAssets } from "members";
+import { Member, MemberChip, useMembersWithAssets } from "members";
+import { MemberNFT } from "nfts/interfaces";
 
 const findMember = (
     memberData: { member: Member; nft?: MemberNFT },

--- a/packages/webapp/src/members/components/home/members-list.tsx
+++ b/packages/webapp/src/members/components/home/members-list.tsx
@@ -7,18 +7,21 @@ import {
 } from "react-virtualized";
 
 import { LoadingContainer, MessageContainer } from "_app/ui";
-import { MemberChip, MemberNFT, useMembersWithAssets } from "members";
+import { Member, MemberChip, MemberNFT, useMembersWithAssets } from "members";
 
-const findMember = (member: MemberNFT, query: string) =>
-    member.account.includes(query.toLowerCase()) ||
-    member.name.toLowerCase().includes(query.toLowerCase());
+const findMember = (
+    memberData: { member: Member; nft?: MemberNFT },
+    query: string
+) =>
+    memberData.member.accountName.includes(query.toLowerCase()) ||
+    memberData.member.profile.name.toLowerCase().includes(query.toLowerCase());
 
 interface Props {
     searchValue: string;
 }
 
 export const MembersList = ({ searchValue }: Props) => {
-    const { members: allMembers, isLoading, isError } = useMembersWithAssets();
+    const { data, isLoading, isError } = useMembersWithAssets();
 
     if (isLoading) {
         return <LoadingContainer />;
@@ -33,7 +36,7 @@ export const MembersList = ({ searchValue }: Props) => {
         );
     }
 
-    if (!allMembers.length) {
+    if (!data.length) {
         return (
             <MessageContainer
                 title="No members found"
@@ -42,8 +45,8 @@ export const MembersList = ({ searchValue }: Props) => {
         );
     }
 
-    const members = allMembers.filter((member) =>
-        findMember(member, searchValue)
+    const members = data.filter((memberData) =>
+        findMember(memberData, searchValue)
     );
 
     return (
@@ -62,13 +65,16 @@ export const MembersList = ({ searchValue }: Props) => {
                     onScroll={onChildScroll}
                     rowCount={members.length}
                     rowHeight={77}
-                    rowRenderer={({ index, style }: ListRowProps) => (
-                        <MemberChip
-                            member={members[index]}
-                            key={members[index].account}
-                            style={style}
-                        />
-                    )}
+                    rowRenderer={({ index, style }: ListRowProps) => {
+                        const { nft, member } = members[index];
+                        return (
+                            <MemberChip
+                                member={nft ?? member}
+                                key={nft?.account ?? member.accountName}
+                                style={style}
+                            />
+                        );
+                    }}
                     noRowsRenderer={() => (
                         <MessageContainer
                             title="No search results"

--- a/packages/webapp/src/members/components/home/members-list.tsx
+++ b/packages/webapp/src/members/components/home/members-list.tsx
@@ -7,9 +7,9 @@ import {
 } from "react-virtualized";
 
 import { LoadingContainer, MessageContainer } from "_app/ui";
-import { MemberChip, MemberData, useMembersWithAssets } from "members";
+import { MemberChip, MemberNFT, useMembersWithAssets } from "members";
 
-const findMember = (member: MemberData, query: string) =>
+const findMember = (member: MemberNFT, query: string) =>
     member.account.includes(query.toLowerCase()) ||
     member.name.toLowerCase().includes(query.toLowerCase());
 

--- a/packages/webapp/src/members/components/member-chip-components/nft-info.tsx
+++ b/packages/webapp/src/members/components/member-chip-components/nft-info.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import { atomicAssets } from "config";
 import { assetToLocaleString, openInNewTab, useCountdown } from "_app";
 import { NFT } from "_app/ui/icons";
-import { AssetData, MemberAuctionData, MemberData } from "members";
+import { AssetData, MemberAuctionData, MemberNFT } from "members";
 
-export const NFTInfo = ({ member }: { member: MemberData }) => {
+export const NFTInfo = ({ member }: { member: MemberNFT }) => {
     if (member.auctionData) {
         return <AuctionBadge auctionData={member.auctionData} />;
     }

--- a/packages/webapp/src/members/components/member-chip-components/nft-info.tsx
+++ b/packages/webapp/src/members/components/member-chip-components/nft-info.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { atomicAssets } from "config";
 import { assetToLocaleString, openInNewTab, useCountdown } from "_app";
 import { NFT } from "_app/ui/icons";
-import { AssetData, MemberAuctionData, MemberNFT } from "members";
+import { MemberNFTAssetData, MemberNFTAuctionData, MemberNFT } from "nfts";
 
 export const NFTInfo = ({ member }: { member: MemberNFT }) => {
     if (member.auctionData) {
@@ -23,7 +23,11 @@ export const NFTInfo = ({ member }: { member: MemberNFT }) => {
 
 export default NFTInfo;
 
-const AuctionBadge = ({ auctionData }: { auctionData: MemberAuctionData }) => {
+const AuctionBadge = ({
+    auctionData,
+}: {
+    auctionData: MemberNFTAuctionData;
+}) => {
     const countdown = useCountdown({
         endTime: new Date(auctionData.bidEndTime as number),
         interval: 30000,
@@ -52,7 +56,7 @@ const SaleBadge = ({
     assetData,
     saleId,
 }: {
-    assetData: AssetData;
+    assetData: MemberNFTAssetData;
     saleId: string;
 }) => (
     <div
@@ -68,7 +72,7 @@ const SaleBadge = ({
     </div>
 );
 
-const AssetBadge = ({ assetData }: { assetData: AssetData }) => (
+const AssetBadge = ({ assetData }: { assetData: MemberNFTAssetData }) => (
     <NFTBadge
         onClick={(e) => {
             e.stopPropagation();

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -5,9 +5,10 @@ import dayjs from "dayjs";
 import { blockExplorerAccountBaseUrl } from "config";
 import { ROUTES } from "_app/routes";
 import { GenericMemberChip, ipfsUrl, openInNewTab } from "_app";
+import { MemberNFT } from "nfts/interfaces";
 
 import { MemberChipTelegramLink, NFTInfo } from "./member-chip-components";
-import { Member, MemberNFT } from "../interfaces";
+import { Member } from "../interfaces";
 
 const isNFT = (member: Member | MemberNFT): member is MemberNFT =>
     (member as MemberNFT).name !== undefined;

--- a/packages/webapp/src/members/components/member-chip.tsx
+++ b/packages/webapp/src/members/components/member-chip.tsx
@@ -4,31 +4,58 @@ import dayjs from "dayjs";
 
 import { blockExplorerAccountBaseUrl } from "config";
 import { ROUTES } from "_app/routes";
-import { GenericMemberChip, openInNewTab } from "_app";
+import { GenericMemberChip, ipfsUrl, openInNewTab } from "_app";
 
 import { MemberChipTelegramLink, NFTInfo } from "./member-chip-components";
-import { MemberData } from "../interfaces";
+import { Member, MemberNFT } from "../interfaces";
+
+const isNFT = (member: Member | MemberNFT): member is MemberNFT =>
+    (member as MemberNFT).name !== undefined;
 
 interface MemberChipProps {
-    member: MemberData;
+    member: Member | MemberNFT;
     [x: string]: any;
 }
 
 export const MemberChip = ({ member, ...containerProps }: MemberChipProps) => {
     const router = useRouter();
 
+    let accountName: string;
+    let name: string;
+
+    if (isNFT(member)) {
+        accountName = member.account;
+        name = member.name;
+    } else {
+        accountName = member.accountName;
+        name = member.profile.name;
+    }
+
     const onClick = (e: React.MouseEvent) => {
-        if (member.account) {
+        if (accountName) {
             e.stopPropagation();
-            router.push(`${ROUTES.MEMBERS.href}/${member.account}`);
+            router.push(`${ROUTES.MEMBERS.href}/${accountName}`);
         } else {
-            openInNewTab(`${blockExplorerAccountBaseUrl}/${member.name}`);
+            openInNewTab(`${blockExplorerAccountBaseUrl}/${name}`);
         }
     };
 
+    if (isNFT(member)) {
+        return (
+            <GenericMemberChip
+                imageUrl={ipfsUrl(member.image)}
+                onClickChip={onClick}
+                contentComponent={
+                    <MemberNFTDetails member={member} onClick={onClick} />
+                }
+                {...containerProps}
+            />
+        );
+    }
+
     return (
         <GenericMemberChip
-            member={member}
+            imageUrl={member.profile.image.url}
             onClickChip={onClick}
             contentComponent={
                 <MemberDetails member={member} onClick={onClick} />
@@ -40,14 +67,13 @@ export const MemberChip = ({ member, ...containerProps }: MemberChipProps) => {
 
 export default MemberChip;
 
-interface MemberDetailsProps {
-    member: MemberData;
+interface MemberNFTDetailsProps {
+    member: MemberNFT;
     onClick?: (e: React.MouseEvent) => void;
 }
 
-const MemberDetails = ({ member, onClick }: MemberDetailsProps) => {
+const MemberNFTDetails = ({ member, onClick }: MemberNFTDetailsProps) => {
     const hasNftInfo = member.auctionData || member.assetData;
-    const isNotMember = member.createdAt === 0;
     const formattedJoinDate = dayjs(member.createdAt).format("YYYY.MM.DD");
 
     return (
@@ -55,14 +81,38 @@ const MemberDetails = ({ member, onClick }: MemberDetailsProps) => {
             <div className="flex items-center space-x-1 text-xs text-gray-500 font-light">
                 {hasNftInfo ? (
                     <NFTInfo member={member} />
-                ) : isNotMember ? (
-                    <p>not an eden member</p>
                 ) : (
                     <p>Joined {formattedJoinDate}</p>
                 )}
             </div>
             <p className="hover:underline">{member.name}</p>
             <MemberChipTelegramLink handle={member.socialHandles.telegram} />
+        </div>
+    );
+};
+
+interface MemberDetailsProps {
+    member: Member;
+    onClick?: (e: React.MouseEvent) => void;
+}
+
+const MemberDetails = ({ member, onClick }: MemberDetailsProps) => {
+    const isNotMember = member.createdAt === 0;
+    const formattedJoinDate = dayjs(member.createdAt).format("YYYY.MM.DD");
+
+    return (
+        <div onClick={onClick} className="flex-1 flex flex-col justify-center">
+            <div className="flex items-center space-x-1 text-xs text-gray-500 font-light">
+                {isNotMember ? (
+                    <p>not an eden member</p>
+                ) : (
+                    <p>Joined {formattedJoinDate}</p>
+                )}
+            </div>
+            <p className="hover:underline">{member.profile.name}</p>
+            <MemberChipTelegramLink
+                handle={member.profile.socialHandles.telegram}
+            />
         </div>
     );
 };

--- a/packages/webapp/src/members/components/member-collections.tsx
+++ b/packages/webapp/src/members/components/member-collections.tsx
@@ -3,9 +3,10 @@ import { Tab } from "@headlessui/react";
 
 import { Container, LoadingContainer, MessageContainer, Text } from "_app";
 import { MemberChip, MembersGrid } from "members";
-
-import { Member, MemberNFT } from "../interfaces";
 import { useMemberNFTCollection, useMemberNFTCollectors } from "nfts/hooks";
+import { MemberNFT } from "nfts/interfaces";
+
+import { Member } from "../interfaces";
 
 interface Props {
     member: Member;

--- a/packages/webapp/src/members/components/member-collections.tsx
+++ b/packages/webapp/src/members/components/member-collections.tsx
@@ -4,7 +4,7 @@ import { Tab } from "@headlessui/react";
 import { Container, LoadingContainer, MessageContainer, Text } from "_app";
 import { MemberChip, MembersGrid } from "members";
 
-import { Member } from "../interfaces";
+import { Member, MemberNFT } from "../interfaces";
 import { useMemberNFTCollection, useMemberNFTCollectors } from "nfts/hooks";
 
 interface Props {
@@ -92,7 +92,7 @@ const Collection = ({
                 </Text>
             </Container>
             <MembersGrid members={nfts}>
-                {(member) => (
+                {(member: MemberNFT) => (
                     <MemberChip
                         key={`member-collection-${member.account}`}
                         member={member}
@@ -143,7 +143,7 @@ const Collectors = ({
                 </Text>
             </Container>
             <MembersGrid members={collectors}>
-                {(member) => (
+                {(member: MemberNFT) => (
                     <MemberChip
                         key={`member-collector-${member.account}`}
                         member={member}

--- a/packages/webapp/src/members/components/member-social-links.tsx
+++ b/packages/webapp/src/members/components/member-social-links.tsx
@@ -5,12 +5,12 @@ import { IoChatbubblesOutline } from "react-icons/io5";
 import { explorerAccountUrl, SocialButton } from "_app";
 import { EosCommunityIcon } from "_app/ui/icons";
 
+import { MemberSocialHandles } from "../interfaces";
 import { getValidSocialLink } from "../helpers/social-links";
-import { EdenNftSocialHandles } from "nfts";
 
 interface Props {
     accountName: string;
-    socialHandles: EdenNftSocialHandles;
+    socialHandles: MemberSocialHandles;
 }
 
 export const MemberSocialLinks = ({ accountName, socialHandles }: Props) => {

--- a/packages/webapp/src/members/components/members-grid.tsx
+++ b/packages/webapp/src/members/components/members-grid.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { Member, MemberNFT } from "../interfaces";
+
+import { MemberNFT } from "nfts/interfaces";
+
+import { Member } from "../interfaces";
 
 interface Props {
     members?: Member[] | MemberNFT[];

--- a/packages/webapp/src/members/components/members-grid.tsx
+++ b/packages/webapp/src/members/components/members-grid.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { MemberData } from "../interfaces";
+import { Member, MemberNFT } from "../interfaces";
 
 interface Props {
-    members?: MemberData[];
+    members?: Member[] | MemberNFT[];
     dataTestId?: string;
     children(
-        value: MemberData,
+        value: Member | MemberNFT,
         index: number,
-        array: MemberData[]
+        array: Member[] | MemberNFT[]
     ): React.ReactNode;
     maxCols?: 1 | 2 | 3;
 }

--- a/packages/webapp/src/members/helpers/formatters.ts
+++ b/packages/webapp/src/members/helpers/formatters.ts
@@ -48,3 +48,15 @@ export const formatMembersQueryNodeAsMember = (
         representativeAccountName: undefined, // Include once exposed
     };
 };
+
+// TODO: Remove after we transition everything we can to Member from MemberNFT
+export const formatMemberAsMemberNFT = (member: Member): MemberNFT => ({
+    createdAt: member.createdAt,
+    account: member.accountName,
+    name: member.profile.name,
+    image: member.profile.image.cid,
+    attributions: member.profile.image.attributions,
+    bio: member.profile.bio,
+    socialHandles: member.profile.socialHandles,
+    inductionVideo: member.inductionVideo.cid,
+});

--- a/packages/webapp/src/members/helpers/formatters.ts
+++ b/packages/webapp/src/members/helpers/formatters.ts
@@ -1,13 +1,13 @@
 import { ipfsUrl } from "_app";
-import { Member, MemberData, MembersQueryNode } from "members/interfaces";
+import { Member, MemberNFT, MembersQueryNode } from "members/interfaces";
 
 /********************************************
  * MICROCHAIN GRAPHQL QUERY RESULT FORMATTERS
  *******************************************/
 
-export const formatQueriedMemberData = (
+export const formatMembersQueryNodeAsMemberNFT = (
     data: MembersQueryNode
-): MemberData | undefined => {
+): MemberNFT | undefined => {
     if (!data) return;
     return {
         createdAt: data.createdAt ? new Date(data.createdAt).getTime() : 0,
@@ -21,7 +21,7 @@ export const formatQueriedMemberData = (
     };
 };
 
-export const formatQueriedMemberDataAsMember = (
+export const formatMembersQueryNodeAsMember = (
     data: MembersQueryNode
 ): Member | undefined => {
     if (!data) return;

--- a/packages/webapp/src/members/helpers/formatters.ts
+++ b/packages/webapp/src/members/helpers/formatters.ts
@@ -1,5 +1,6 @@
 import { ipfsUrl } from "_app";
-import { Member, MemberNFT, MembersQueryNode } from "members/interfaces";
+import { Member, MembersQueryNode } from "members/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 
 /********************************************
  * MICROCHAIN GRAPHQL QUERY RESULT FORMATTERS

--- a/packages/webapp/src/members/hooks/queries.ts
+++ b/packages/webapp/src/members/hooks/queries.ts
@@ -2,11 +2,11 @@ import { useQuery as useReactQuery } from "react-query";
 import { useQuery as useBoxQuery } from "@edenos/eden-subchain-client/dist/ReactSubchain";
 
 import {
-    formatQueriedMemberData,
-    formatQueriedMemberDataAsMember,
+    formatMembersQueryNodeAsMemberNFT,
+    formatMembersQueryNodeAsMember,
     getNewMembers,
 } from "members";
-import { MemberData, MembersQuery } from "members/interfaces";
+import { MemberNFT, MembersQuery } from "members/interfaces";
 import { useUALAccount } from "_app";
 
 export const MEMBER_DATA_FRAGMENT = `
@@ -34,14 +34,15 @@ export const useMembers = () => {
         }
     }`);
 
-    let formattedMembers: MemberData[] = [];
+    let formattedMembers: MemberNFT[] = [];
 
     if (!result.data) return { ...result, data: formattedMembers };
 
     const memberEdges = result.data.members.edges;
     if (memberEdges) {
         formattedMembers = memberEdges.map(
-            (member) => formatQueriedMemberData(member.node) as MemberData
+            (member) =>
+                formatMembersQueryNodeAsMemberNFT(member.node) as MemberNFT
         );
     }
 
@@ -72,11 +73,11 @@ export const useMemberByAccountName = (account: string) => {
     if (!result.data) return { ...result, data: null };
 
     const memberNode = result.data.members.edges[0]?.node;
-    const member = formatQueriedMemberData(memberNode) ?? null;
+    const member = formatMembersQueryNodeAsMemberNFT(memberNode) ?? null;
     return { ...result, data: member };
 };
 
-const sortMembersByDateDESC = (a: MemberData, b: MemberData) =>
+const sortMembersByDateDESC = (a: MemberNFT, b: MemberNFT) =>
     b.createdAt - a.createdAt;
 
 export const queryNewMembers = (page: number, pageSize: number) => ({
@@ -96,10 +97,10 @@ export const useMembersWithAssets = () => {
     const isError =
         newMembers.isError || allMembers.isError || !allMembers.data;
 
-    let members: MemberData[] = [];
+    let members: MemberNFT[] = [];
 
     if (allMembers.data.length) {
-        const mergeAuctionData = (member: MemberData) => {
+        const mergeAuctionData = (member: MemberNFT) => {
             const newMemberRecord = newMembers.data?.find(
                 (newMember) => newMember.account === member.account
             );
@@ -128,7 +129,7 @@ export const useMemberByAccountNameAsMember = (account: string) => {
     if (!result.data) return { ...result, data: null };
 
     const memberNode = result.data.members.edges[0]?.node;
-    const member = formatQueriedMemberDataAsMember(memberNode) ?? null;
+    const member = formatMembersQueryNodeAsMember(memberNode) ?? null;
     return { ...result, data: member };
 };
 

--- a/packages/webapp/src/members/hooks/queries.ts
+++ b/packages/webapp/src/members/hooks/queries.ts
@@ -1,13 +1,14 @@
 import { useQuery as useReactQuery } from "react-query";
 import { useQuery as useBoxQuery } from "@edenos/eden-subchain-client/dist/ReactSubchain";
 
+import { useUALAccount } from "_app";
 import {
     formatMembersQueryNodeAsMember,
     getNewMembers,
     formatMemberAsMemberNFT,
 } from "members";
-import { Member, MemberNFT, MembersQuery } from "members/interfaces";
-import { useUALAccount } from "_app";
+import { Member, MembersQuery } from "members/interfaces";
+import { MemberNFT } from "nfts/interfaces";
 
 export const MEMBER_DATA_FRAGMENT = `
     createdAt

--- a/packages/webapp/src/members/hooks/queries.ts
+++ b/packages/webapp/src/members/hooks/queries.ts
@@ -2,11 +2,11 @@ import { useQuery as useReactQuery } from "react-query";
 import { useQuery as useBoxQuery } from "@edenos/eden-subchain-client/dist/ReactSubchain";
 
 import {
-    formatMembersQueryNodeAsMemberNFT,
     formatMembersQueryNodeAsMember,
     getNewMembers,
+    formatMemberAsMemberNFT,
 } from "members";
-import { MemberNFT, MembersQuery } from "members/interfaces";
+import { Member, MemberNFT, MembersQuery } from "members/interfaces";
 import { useUALAccount } from "_app";
 
 export const MEMBER_DATA_FRAGMENT = `
@@ -34,88 +34,21 @@ export const useMembers = () => {
         }
     }`);
 
-    let formattedMembers: MemberNFT[] = [];
+    let formattedMembers: Member[] = [];
 
     if (!result.data) return { ...result, data: formattedMembers };
 
     const memberEdges = result.data.members.edges;
     if (memberEdges) {
         formattedMembers = memberEdges.map(
-            (member) =>
-                formatMembersQueryNodeAsMemberNFT(member.node) as MemberNFT
+            (member) => formatMembersQueryNodeAsMember(member.node) as Member
         );
     }
 
     return { ...result, data: formattedMembers };
 };
 
-export const useMembersByAccountNames = (
-    accountNames: string[] | undefined = []
-) => {
-    const { data: allMembers, ...memberQueryMetaData } = useMembers();
-    const members = allMembers.filter((member) =>
-        accountNames.includes(member.account)
-    );
-    return { data: members, ...memberQueryMetaData };
-};
-
 export const useMemberByAccountName = (account: string) => {
-    const result = useBoxQuery<MembersQuery>(`{
-        members(ge: "${account}", le: "${account}") {
-            edges {
-                node {
-                    ${MEMBER_DATA_FRAGMENT}
-                }
-            }
-        }
-    }`);
-
-    if (!result.data) return { ...result, data: null };
-
-    const memberNode = result.data.members.edges[0]?.node;
-    const member = formatMembersQueryNodeAsMemberNFT(memberNode) ?? null;
-    return { ...result, data: member };
-};
-
-const sortMembersByDateDESC = (a: MemberNFT, b: MemberNFT) =>
-    b.createdAt - a.createdAt;
-
-export const queryNewMembers = (page: number, pageSize: number) => ({
-    queryKey: ["query_new_members", page, pageSize],
-    queryFn: () => getNewMembers(page, pageSize),
-});
-
-export const useMembersWithAssets = () => {
-    const NEW_MEMBERS_PAGE_SIZE = 10000;
-    const newMembers = useReactQuery({
-        ...queryNewMembers(1, NEW_MEMBERS_PAGE_SIZE),
-    });
-
-    const allMembers = useMembers();
-
-    const isLoading = newMembers.isLoading || allMembers.isLoading;
-    const isError =
-        newMembers.isError || allMembers.isError || !allMembers.data;
-
-    let members: MemberNFT[] = [];
-
-    if (allMembers.data.length) {
-        const mergeAuctionData = (member: MemberNFT) => {
-            const newMemberRecord = newMembers.data?.find(
-                (newMember) => newMember.account === member.account
-            );
-            return newMemberRecord ?? member;
-        };
-
-        members = allMembers.data
-            .sort(sortMembersByDateDESC)
-            .map(mergeAuctionData);
-    }
-
-    return { members, isLoading, isError };
-};
-
-export const useMemberByAccountNameAsMember = (account: string) => {
     const result = useBoxQuery<MembersQuery>(`{
         members(ge: "${account}", le: "${account}") {
             edges {
@@ -135,5 +68,69 @@ export const useMemberByAccountNameAsMember = (account: string) => {
 
 export const useCurrentMember = () => {
     const [ualAccount] = useUALAccount();
-    return useMemberByAccountNameAsMember(ualAccount?.accountName);
+    return useMemberByAccountName(ualAccount?.accountName);
+};
+
+export const useMembersByAccountNames = (
+    accountNames: string[] | undefined = []
+) => {
+    const { data: allMembers, ...memberQueryMetaData } = useMembers();
+    const members = allMembers.filter((member) =>
+        accountNames.includes(member.accountName)
+    );
+    return { data: members, ...memberQueryMetaData };
+};
+
+const sortMembersByDateDESC = (a: Member, b: Member) =>
+    b.createdAt - a.createdAt;
+
+export const queryNewMembers = (page: number, pageSize: number) => ({
+    queryKey: ["query_new_members", page, pageSize],
+    queryFn: () => getNewMembers(page, pageSize),
+});
+
+export const useMembersWithAssets = () => {
+    const NEW_MEMBERS_PAGE_SIZE = 10000;
+    const newMembers = useReactQuery({
+        ...queryNewMembers(1, NEW_MEMBERS_PAGE_SIZE),
+    });
+
+    const allMembers = useMembers();
+
+    const isLoading = newMembers.isLoading || allMembers.isLoading;
+    const isError =
+        newMembers.isError || allMembers.isError || !allMembers.data;
+
+    if (!allMembers.data.length) {
+        return { data: [], isLoading, isError };
+    }
+
+    const mergeAuctionData = (member: Member) => {
+        const memberNFT = newMembers.data?.find(
+            (newMember) => newMember.account === member.accountName
+        );
+        if (!memberNFT) return { member };
+        return {
+            member,
+            nft: memberNFT,
+        };
+    };
+
+    const data: { member: Member; nft?: MemberNFT }[] = allMembers.data
+        .sort(sortMembersByDateDESC)
+        .map(mergeAuctionData);
+
+    return { data, isLoading, isError };
+};
+
+/********************************************************************************
+ * TODO: Refactor the following away once reliant components use Member interface
+ ********************************************************************************/
+
+export const useMembersByAccountNamesAsMemberNFTs = (
+    accountNames: string[] | undefined = []
+) => {
+    const query = useMembersByAccountNames(accountNames);
+    const memberNFTs = query.data.map(formatMemberAsMemberNFT);
+    return { ...query, data: memberNFTs };
 };

--- a/packages/webapp/src/members/interfaces.ts
+++ b/packages/webapp/src/members/interfaces.ts
@@ -38,7 +38,8 @@ export interface Member {
     representativeAccountName?: string; // Include once exposed
 }
 
-export interface MemberData {
+// TODO: Move to NFT interfaces file.
+export interface MemberNFT {
     createdAt: number;
     account: string;
     name: string;

--- a/packages/webapp/src/members/interfaces.ts
+++ b/packages/webapp/src/members/interfaces.ts
@@ -1,5 +1,4 @@
-import { EdenNftSocialHandles } from "nfts/interfaces";
-import { Asset, ElectionParticipationStatus, MemberStatus } from "_app";
+import { ElectionParticipationStatus, MemberStatus } from "_app";
 
 export type VoteDataQueryOptionsByField = {
     fieldName?: string;
@@ -21,7 +20,16 @@ interface MemberProfile {
     name: string;
     image: ProfileImage;
     bio: string;
-    socialHandles: EdenNftSocialHandles;
+    socialHandles: MemberSocialHandles;
+}
+
+export interface MemberSocialHandles {
+    eosCommunity?: string;
+    twitter?: string;
+    linkedin?: string;
+    telegram?: string;
+    facebook?: string;
+    blog?: string;
 }
 
 export interface Member {
@@ -36,33 +44,6 @@ export interface Member {
     participatingInElection: boolean;
     delegateRank?: number; // Include once exposed
     representativeAccountName?: string; // Include once exposed
-}
-
-// TODO: Move to NFT interfaces file.
-export interface MemberNFT {
-    createdAt: number;
-    account: string;
-    name: string;
-    image: string;
-    attributions: string;
-    bio: string;
-    socialHandles: EdenNftSocialHandles;
-    inductionVideo: string;
-    templateId?: number;
-    auctionData?: MemberAuctionData;
-    assetData?: AssetData;
-    saleId?: string;
-}
-
-export interface AssetData {
-    assetId: string;
-    templateMint: number;
-}
-
-export interface MemberAuctionData {
-    auctionId: string;
-    price: Asset;
-    bidEndTime?: number;
 }
 
 export interface EdenMember {

--- a/packages/webapp/src/nfts/hooks/queries.ts
+++ b/packages/webapp/src/nfts/hooks/queries.ts
@@ -2,18 +2,22 @@ import { useQuery as useReactQuery } from "react-query";
 import { useQuery as useBoxQuery } from "@edenos/eden-subchain-client/dist/ReactSubchain";
 
 import { atomicAssets, edenContractAccount } from "config";
-import { formatQueriedMemberData, MEMBER_DATA_FRAGMENT } from "members";
-import { getCollection, memberDataDefaults } from "members/api";
-import { MemberData, MembersQueryNode } from "members/interfaces";
+import {
+    formatMembersQueryNodeAsMemberNFT,
+    MEMBER_DATA_FRAGMENT,
+} from "members";
+import { getCollection, memberNFTDefaults } from "members/api";
+import { MemberNFT, MembersQueryNode } from "members/interfaces";
 import { NFTCollectorsQuery } from "nfts/interfaces";
 
+// NOTE: Eden member NFTs may be deprecated soon.
 export const queryMemberNFTCollection = (account: string) => ({
     queryKey: ["query_member_nft_collection", account],
     queryFn: () => getCollection(account),
 });
 
 export const useMemberNFTCollection = (account: string) => {
-    return useReactQuery<MemberData[]>({
+    return useReactQuery<MemberNFT[]>({
         ...queryMemberNFTCollection(account),
     });
 };
@@ -37,7 +41,7 @@ export const useMemberNFTCollectors = (account: string) => {
         }
     }`);
 
-    let collectors: MemberData[] = [];
+    let collectors: MemberNFT[] = [];
 
     if (!result.data) return { ...result, data: collectors };
 
@@ -57,7 +61,7 @@ const isAuction = (account: string) =>
 
 const formatCollectorAsMemberData = (owner: MembersQueryNode) => {
     if (owner.profile) {
-        return formatQueriedMemberData(owner) as MemberData;
+        return formatMembersQueryNodeAsMemberNFT(owner) as MemberNFT;
     }
-    return { ...memberDataDefaults, name: owner.account };
+    return { ...memberNFTDefaults, name: owner.account };
 };

--- a/packages/webapp/src/nfts/hooks/queries.ts
+++ b/packages/webapp/src/nfts/hooks/queries.ts
@@ -7,8 +7,8 @@ import {
     MEMBER_DATA_FRAGMENT,
 } from "members";
 import { getCollection, memberNFTDefaults } from "members/api";
-import { MemberNFT, MembersQueryNode } from "members/interfaces";
-import { NFTCollectorsQuery } from "nfts/interfaces";
+import { MembersQueryNode } from "members/interfaces";
+import { MemberNFT, NFTCollectorsQuery } from "nfts/interfaces";
 
 // NOTE: Eden member NFTs may be deprecated soon.
 export const queryMemberNFTCollection = (account: string) => ({

--- a/packages/webapp/src/nfts/interfaces.ts
+++ b/packages/webapp/src/nfts/interfaces.ts
@@ -1,24 +1,38 @@
 import { Asset } from "_app";
-import { MembersQueryNode } from "members/interfaces";
+import { MembersQueryNode, MemberSocialHandles } from "members/interfaces";
 
-export interface EdenNftData {
-    name: string;
-    img: string;
+/******************************
+ * NFT UI INTERFACES
+ *****************************/
+export interface MemberNFT {
+    createdAt: number;
     account: string;
-    bio: string;
-    video: string;
+    name: string;
+    image: string;
     attributions: string;
-    social?: string;
+    bio: string;
+    socialHandles: MemberSocialHandles;
+    inductionVideo: string;
+    templateId?: number;
+    auctionData?: MemberNFTAuctionData;
+    assetData?: MemberNFTAssetData;
+    saleId?: string;
 }
 
-export interface EdenNftSocialHandles {
-    eosCommunity?: string;
-    twitter?: string;
-    linkedin?: string;
-    telegram?: string;
-    facebook?: string;
-    blog?: string;
+export interface MemberNFTAuctionData {
+    auctionId: string;
+    price: Asset;
+    bidEndTime?: number;
 }
+
+export interface MemberNFTAssetData {
+    assetId: string;
+    templateMint: number;
+}
+
+/******************************
+ * NFT API INTERFACES
+ *****************************/
 
 export interface TemplateData {
     template_id: string;
@@ -40,6 +54,16 @@ export interface AuctionableTemplateData extends TemplateData {
     endTime: number;
     assetId: string;
     templateMint: number;
+}
+
+interface EdenNftData {
+    name: string;
+    img: string;
+    account: string;
+    bio: string;
+    video: string;
+    attributions: string;
+    social?: string;
 }
 
 /******************************

--- a/packages/webapp/src/pages/delegates/index.tsx
+++ b/packages/webapp/src/pages/delegates/index.tsx
@@ -9,13 +9,16 @@ import {
 } from "_app";
 import { Container, Heading, LoadingContainer, Text } from "_app/ui";
 import { ElectionStatus } from "elections/interfaces";
-import { MemberGateContainer, useMembersByAccountNames } from "members";
+import {
+    MemberGateContainer,
+    useMembersByAccountNamesAsMemberNFTs,
+} from "members";
 import {
     ErrorLoadingDelegation,
     ElectionInProgress,
     NoDelegationToDisplay,
 } from "delegates/components/statuses";
-import MyDelegation from "delegates/components/my-delegation"; // avoid circular depenency
+import MyDelegation from "delegates/components/my-delegation"; // avoid circular dependency
 
 export const DelegatesPage = () => {
     const {
@@ -44,7 +47,7 @@ export const DelegatesPage = () => {
         data: myDelegationMemberData,
         isLoading: isLoadingMemberData,
         isError: isErrorMemberData,
-    } = useMembersByAccountNames(
+    } = useMembersByAccountNamesAsMemberNFTs(
         myDelegation?.map((delegate) => delegate.account)
     );
 

--- a/packages/webapp/src/pages/election/components.tsx
+++ b/packages/webapp/src/pages/election/components.tsx
@@ -5,7 +5,7 @@ import { dehydrate } from "react-query/hydration";
 
 import { FluidLayout, queryMembersStats, queryMembers } from "_app";
 import { Container, Heading } from "_app/ui";
-import { MembersGrid } from "members";
+import { MemberNFT, MembersGrid } from "members";
 import { VotingMemberChip, DelegateChip } from "elections";
 
 const MEMBERS_PAGE_SIZE = 18;
@@ -48,7 +48,7 @@ export const MembersPage = (props: Props) => {
             </Container>
             <MembersGrid members={members.data}>
                 {/* TODO: Hard-coded values here should come from fixtures. */}
-                {(member) => (
+                {(member: MemberNFT) => (
                     <VotingMemberChip
                         key={`voting-chips-${member.account}`}
                         member={member}
@@ -70,7 +70,7 @@ export const MembersPage = (props: Props) => {
                 {members.error && "Fail to load members"}
             </Container>
             <MembersGrid members={members.data?.slice(1, 2)}>
-                {(member) => (
+                {(member: MemberNFT) => (
                     <DelegateChip
                         key={`delegate-chip-${member.account}`}
                         member={member}

--- a/packages/webapp/src/pages/election/components.tsx
+++ b/packages/webapp/src/pages/election/components.tsx
@@ -5,7 +5,8 @@ import { dehydrate } from "react-query/hydration";
 
 import { FluidLayout, queryMembersStats, queryMembers } from "_app";
 import { Container, Heading } from "_app/ui";
-import { MemberNFT, MembersGrid } from "members";
+import { MembersGrid } from "members";
+import { MemberNFT } from "nfts/interfaces";
 import { VotingMemberChip, DelegateChip } from "elections";
 
 const MEMBERS_PAGE_SIZE = 18;

--- a/packages/webapp/src/pages/election/round-video-upload.tsx
+++ b/packages/webapp/src/pages/election/round-video-upload.tsx
@@ -22,14 +22,13 @@ import {
     VideoSubmissionFormAndPreview,
     VideoSubmissionPhase,
 } from "_app/ui";
-
 import {
     ElectionStatus,
     ErrorLoadingElection,
     setElectionRoundVideo,
 } from "elections";
 import { RoundHeader } from "elections/components/ongoing-election-components";
-import { MemberData, MemberGateContainer } from "members";
+import { MemberNFT, MemberGateContainer } from "members";
 
 export const RoundVideoUploadPage = () => {
     const {
@@ -254,7 +253,7 @@ const LoaderSection = () => (
 interface HeaderProps {
     isOngoing: boolean;
     roundIndex: number;
-    winner?: MemberData;
+    winner?: MemberNFT;
     roundStartTime?: dayjs.Dayjs;
     roundEndTime?: dayjs.Dayjs;
 }

--- a/packages/webapp/src/pages/election/round-video-upload.tsx
+++ b/packages/webapp/src/pages/election/round-video-upload.tsx
@@ -28,7 +28,8 @@ import {
     setElectionRoundVideo,
 } from "elections";
 import { RoundHeader } from "elections/components/ongoing-election-components";
-import { MemberNFT, MemberGateContainer } from "members";
+import { MemberGateContainer } from "members";
+import { MemberNFT } from "nfts/interfaces";
 
 export const RoundVideoUploadPage = () => {
     const {

--- a/packages/webapp/src/pages/election/stats.tsx
+++ b/packages/webapp/src/pages/election/stats.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import {
     RoundBasicQueryData,
     RoundGroupQueryData,
@@ -8,7 +9,6 @@ import {
     useCurrentGlobalElectionData,
 } from "_app";
 import { Container, Heading, Loader, Expander, Text } from "_app/ui";
-
 import {
     Avatars,
     DelegateChip,
@@ -18,7 +18,7 @@ import {
     VoteData,
     VotingMemberChip,
 } from "elections";
-import { MemberData, MembersGrid } from "members";
+import { MemberNFT, MembersGrid } from "members";
 import { RoundHeader } from "elections/components/ongoing-election-components";
 import { ConsensometerBlocks } from "elections/components/ongoing-election-components/ongoing-round/round-info/consensometer";
 
@@ -183,7 +183,7 @@ const GroupSegment = ({
     // TODO: revisit this, unfortunately the MembersGrid only accepts MemberData,
     // even though we don't need it to display the required summarized member
     // chip data
-    const members: MemberData[] = group.votes.map((vote) => vote.voter);
+    const members: MemberNFT[] = group.votes.map((vote) => vote.voter);
 
     const membersStats = group.votes.reduce((membersVotingMap, vote) => {
         membersVotingMap[vote.voter.account] = {
@@ -224,7 +224,7 @@ const GroupSegment = ({
 };
 
 interface GroupProps {
-    members: MemberData[];
+    members: MemberNFT[];
     isFinished: boolean;
     groupMembersStats: GroupMembersStats;
     header?: React.ReactNode;
@@ -234,7 +234,7 @@ const RegularGroup = ({ members, groupMembersStats, header }: GroupProps) => {
     return (
         <Expander header={header} type="inactive">
             <MembersGrid members={members} maxCols={2}>
-                {(member) => {
+                {(member: MemberNFT) => {
                     return (
                         <VotingMemberChip
                             key={`voting-member-${member.account}`}
@@ -266,7 +266,7 @@ const ChiefDelegateGroup = ({
 }: GroupProps) => {
     return (
         <MembersGrid members={members}>
-            {(member) => {
+            {(member: MemberNFT) => {
                 const delegateTitle =
                     isFinished && groupMembersStats[member.account].isDelegate
                         ? "Head Chief"

--- a/packages/webapp/src/pages/election/stats.tsx
+++ b/packages/webapp/src/pages/election/stats.tsx
@@ -18,7 +18,8 @@ import {
     VoteData,
     VotingMemberChip,
 } from "elections";
-import { MemberNFT, MembersGrid } from "members";
+import { MembersGrid } from "members";
+import { MemberNFT } from "nfts/interfaces";
 import { RoundHeader } from "elections/components/ongoing-election-components";
 import { ConsensometerBlocks } from "elections/components/ongoing-election-components/ongoing-round/round-info/consensometer";
 

--- a/packages/webapp/src/pages/members/[id].tsx
+++ b/packages/webapp/src/pages/members/[id].tsx
@@ -12,13 +12,13 @@ import {
     MemberCard,
     MemberCollections,
     MemberHoloCard,
-    useMemberByAccountNameAsMember,
+    useMemberByAccountName,
 } from "members";
 import { FundsAvailableCTA } from "members/components";
 
 export const MemberPage = () => {
     const router = useRouter();
-    const { data: member, isLoading, isError } = useMemberByAccountNameAsMember(
+    const { data: member, isLoading, isError } = useMemberByAccountName(
         router.query.id as string
     );
 


### PR DESCRIPTION
## Description

This is a continuation of the gradual refactor of the frontend. 

Data in the `MemberData` interface comes from AtomicAssets. It _is_ the member's NFT information. `Member` data on the other hand now comes from the subchain. In the future, a member's _current_ profile information may differ from the (older) information in their NFT.

For this reason, and for the sake of clarity--especially as we refactor--I have renamed `MemberData` to `MemberNFT`. The real data for a member will now be found in the `Member` interface/model.

To restate the rule from now on: If we want a member's profile or current Eden membership status/data, we should get that from the subchain/box (via the `Member` interface). If we want a member's NFT information (including profile information as minted in that NFT), we should get that from the AtomicHub APIs (via the `MemberNFT` interface).

This will also make it easier for us to remove NFTs from the platform, if we so choose.

## In this PR, I also...

- [x] adjust member chips to accept either `Member` or `MemberNFT`, so I can...
- [x] make the main members list page use `Member` and box queries,
- [x] organize/move NFT interfaces into the NFT domain

## Future work
- continue refactoring remaining UI (_e.g._, elections, inductions) to use box queries and the new interfaces