### PR TITLE
Enable LTO for wasm build

### DIFF
--- a/contracts/eden/CMakeLists.txt
+++ b/contracts/eden/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(eden
    src/encrypt.cpp
 )
 target_include_directories(eden PUBLIC include ../token/include PRIVATE ../../external/atomicassets-contract/include)
+target_compile_options(eden PUBLIC -flto)
 target_link_libraries(eden eosio-contract)
 set_target_properties(eden PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ROOT_BINARY_DIR})
 

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -39,8 +39,8 @@ endfunction()
 file(COPY ${ROOT_SOURCE_DIR}/LICENSE DESTINATION ${ROOT_BINARY_DIR}/clsdk/licenses)
 
 add_library(wasm-base INTERFACE)
-target_compile_options(wasm-base INTERFACE -fno-exceptions -D__eosio_cdt__ -mthread-model single -O3 -flto)
-target_link_options(wasm-base INTERFACE -Wl,--strip-all -O3 -flto)
+target_compile_options(wasm-base INTERFACE -fno-exceptions -D__eosio_cdt__ -mthread-model single -O3)
+target_link_options(wasm-base INTERFACE -Wl,--strip-all -O3)
 
 add_library(wasm-base-debug INTERFACE)
 target_compile_options(wasm-base-debug INTERFACE -fno-exceptions -D__eosio_cdt__ -mthread-model single -ggdb)

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -39,8 +39,8 @@ endfunction()
 file(COPY ${ROOT_SOURCE_DIR}/LICENSE DESTINATION ${ROOT_BINARY_DIR}/clsdk/licenses)
 
 add_library(wasm-base INTERFACE)
-target_compile_options(wasm-base INTERFACE -fno-exceptions -D__eosio_cdt__ -mthread-model single -O3)
-target_link_options(wasm-base INTERFACE -Wl,--strip-all -O3)
+target_compile_options(wasm-base INTERFACE -fno-exceptions -D__eosio_cdt__ -mthread-model single -O3 -flto)
+target_link_options(wasm-base INTERFACE -Wl,--strip-all -O3 -flto)
 
 add_library(wasm-base-debug INTERFACE)
 target_compile_options(wasm-base-debug INTERFACE -fno-exceptions -D__eosio_cdt__ -mthread-model single -ggdb)


### PR DESCRIPTION
Reduces the number of function definitions in the contract to fit in the limits.