### PR TITLE
Update call to AH Auctions API to fix members lists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,7 +365,7 @@ jobs:
                   name: Eden Microchain
                   path: build
 
-            - name: Download Ephemeral Chain Runners
+            - name: Download Ephemeral Eden Chain Runners
               if: steps.filter.outputs.src == 'true'
               uses: actions/download-artifact@v2
               with:

--- a/packages/webapp/src/members/hooks/queries.ts
+++ b/packages/webapp/src/members/hooks/queries.ts
@@ -91,7 +91,7 @@ export const queryNewMembers = (page: number, pageSize: number) => ({
 });
 
 export const useMembersWithAssets = () => {
-    const NEW_MEMBERS_PAGE_SIZE = 10000;
+    const NEW_MEMBERS_PAGE_SIZE = 100;
     const newMembers = useReactQuery({
         ...queryNewMembers(1, NEW_MEMBERS_PAGE_SIZE),
     });

--- a/packages/webapp/src/nfts/api/nfts.ts
+++ b/packages/webapp/src/nfts/api/nfts.ts
@@ -38,7 +38,7 @@ export const getAuctions = async (
     seller?: string,
     templateIds?: string[],
     page = 1,
-    limit = 9999
+    limit = 100 // max 100 enforced by AA Auctions API
 ): Promise<AuctionableTemplateData[]> => {
     let url = `${atomicAssets.apiMarketUrl}/auctions?state=1&collection_name=${atomicAssets.collection}&schema_name=${atomicAssets.schema}&page=${page}&limit=${limit}&order=desc&sort=created${FETCH_AFTER_TIMESTAMP}`;
 


### PR DESCRIPTION
AtomicHub updated their policy to fail on invalid inputs. We had the limit set to 10000, which was invalid (100 is max). This is causing the production Community page to error out right now.